### PR TITLE
Add new actor notification workflow

### DIFF
--- a/new_actor_notification.yml
+++ b/new_actor_notification.yml
@@ -1,0 +1,44 @@
+name: Notify Slack on new actor events
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+  discussion:
+    types: [created]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch list of contributors
+        id: fetch_contributors
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const contributors = await github.paginate(github.repos.listContributors, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            return contributors.map(contributor => contributor.login);
+
+      - name: Check if actor is new
+        id: check_actor
+        run: |
+          echo "actor_is_new=false" >> $GITHUB_ENV
+          if [[ ! " ${contributors[*]} " =~ " ${GITHUB_ACTOR} " ]]; then
+            echo "actor_is_new=true" >> $GITHUB_ENV
+          fi
+
+      - name: Send notification to Slack
+        if: env.actor_is_new == 'true'
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          slack-message: |
+            A new event has occurred in the repository.
+            Event type: ${{ github.event_name }}
+            Actor: ${{ github.actor }}
+            Link: ${{ github.event.html_url }}
+            This is an interaction from a new contributor. Please respond ASAP.


### PR DESCRIPTION
Add a new workflow to notify Slack on new actor events.

* Create `new_actor_notification.yml` to handle the functionality.
* Trigger on `issues`, `pull_request`, and `discussion` events.
* Fetch the list of contributors using `actions/github-script`.
* Check if the actor is new by comparing with the list of contributors.
* Send a notification to Slack using `slackapi/slack-github-action` if the actor is new.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/avifenesh/valkey-glide/tree/WF/notfication-on-new-interaction?shareId=a4b61902-c714-4893-b527-04dbb7164113).