### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent stack trace leakage in logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-21 - Prevent Stack Trace Leakage in Logs
+**Vulnerability:** Default logging configuration unconditionally appended full stack traces to error messages.
+**Learning:** Security by default requires careful consideration of what is logged. Stack traces are valuable for debugging but sensitive for production logs.
+**Prevention:** Gate stack trace logging behind explicit 'debug' or 'trace' levels.

--- a/node/AGENTS.md
+++ b/node/AGENTS.md
@@ -11,6 +11,7 @@ This is the Node.js/TypeScript client binding for Valkey GLIDE, providing both s
 **Architecture:** TypeScript wrapper around Rust FFI core with NAPI-RS bindings
 
 **Key Components:**
+
 - `src/` - Main TypeScript client library
 - `rust-client/` - Rust NAPI bindings and FFI integration
 - `build-ts/` - Compiled TypeScript output
@@ -25,6 +26,7 @@ This is the Node.js/TypeScript client binding for Valkey GLIDE, providing both s
 **Protocol:** Protobuf communication with Rust core
 
 **Supported Platforms:**
+
 - Linux: glibc 2.17+, musl libc 1.2.3+ (Alpine)
 - macOS: 13.5+ (x86_64), 15.0+ (aarch64/Apple Silicon)
 - Node.js: 20+ (npm 11+ recommended for Linux)
@@ -34,6 +36,7 @@ This is the Node.js/TypeScript client binding for Valkey GLIDE, providing both s
 ## Build and Test Rules (Agents)
 
 ### Preferred (npm Scripts)
+
 ```bash
 # Build commands
 npm run build                    # Development build (fast, unoptimized)
@@ -64,6 +67,7 @@ npm run clean                   # Complete cleanup including node_modules
 ```
 
 ### Raw Equivalents
+
 ```bash
 # Manual TypeScript compilation
 npx tsc
@@ -85,6 +89,7 @@ npx prettier --check .
 ```
 
 ### Test Execution Options
+
 ```bash
 # Run with existing endpoints
 npm run test:debug -- --cluster-endpoints=localhost:7000 --standalone-endpoints=localhost:6379
@@ -134,17 +139,20 @@ Use conventional commit format:
 ### Code Quality Requirements
 
 **ESLint + Prettier:**
+
 ```bash
 npm run lint                    # Must pass before commit
 npm run lint:fix                # Fix linting and formatting issues
 ```
 
 **TypeScript Compilation:**
+
 ```bash
 npm run build:ts                # Must compile without errors
 ```
 
 **Rust Components:**
+
 ```bash
 # From rust-client/ directory
 cargo clippy --all-features --all-targets -- -D warnings
@@ -154,6 +162,7 @@ cargo fmt --manifest-path ./Cargo.toml --all
 ## Guardrails & Policies
 
 ### Generated Outputs (Never Commit)
+
 - `build-ts/` - Compiled TypeScript output
 - `node_modules/` - Node.js dependencies
 - `rust-client/node_modules/` - Rust client dependencies
@@ -167,6 +176,7 @@ cargo fmt --manifest-path ./Cargo.toml --all
 - `package-lock.json`, `yarn.lock` - Lock files (project uses npm)
 
 ### Node.js-Specific Rules
+
 - **Node.js 20+ Required:** Minimum runtime version
 - **npm 11+ Recommended:** For Linux users (better libc support)
 - **Promise-based APIs:** All client methods return Promises
@@ -175,6 +185,7 @@ cargo fmt --manifest-path ./Cargo.toml --all
 - **NAPI Bindings:** Native module built per platform/architecture
 
 ### TypeScript Guidelines
+
 - Maintain strict TypeScript configuration
 - Export all public APIs through `index.ts`
 - Use proper type definitions for all public interfaces

--- a/node/README.md
+++ b/node/README.md
@@ -14,7 +14,7 @@ Valkey General Language Independent Driver for the Enterprise (GLIDE) is the off
 
 ## Documentation
 
-See GLIDE's Node.js [documentation site](https://glide.valkey.io/languages/nodejs).  
+See GLIDE's Node.js [documentation site](https://glide.valkey.io/languages/nodejs).
 
 ## Supported Engine Versions
 

--- a/node/src/Logger.ts
+++ b/node/src/Logger.ts
@@ -56,7 +56,11 @@ export class Logger {
         }
 
         if (err) {
-            message += `: ${err.stack}`;
+            message += `: ${err.message}`;
+
+            if (logLevel === "debug" || logLevel === "trace") {
+                message += `\nStack: ${err.stack}`;
+            }
         }
 
         const level = LEVEL.get(logLevel) || 0;


### PR DESCRIPTION
This PR modifies `node/src/Logger.ts` to conditionally log stack traces only when the log level is 'debug' or 'trace'. This prevents leaking sensitive internal details in standard production logs.

---
*PR created automatically by Jules for task [5634684496365813413](https://jules.google.com/task/5634684496365813413) started by @avifenesh*