### PR TITLE
🛡️ Sentinel: [HIGH] Fix null pointer dereferences in FFI

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - [FFI Null Pointer Checks]
+**Vulnerability:** Missing null pointer checks in FFI functions (`store_script`, `create_client`, etc.) in `ffi/src/lib.rs`.
+**Learning:** `extern "C"` functions receive raw pointers which can be null. `std::slice::from_raw_parts` and `CStr::from_ptr` cause Undefined Behavior if passed null pointers.
+**Prevention:** Always check `is_null()` on raw pointers at the beginning of `extern "C"` functions and return error or safe default.

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -68,6 +68,9 @@ pub unsafe extern "C" fn store_script(
     script_bytes: *const u8,
     script_len: usize,
 ) -> *mut ScriptHashBuffer {
+    if script_bytes.is_null() {
+        return std::ptr::null_mut();
+    }
     let script = unsafe { std::slice::from_raw_parts(script_bytes, script_len) };
     let hash = scripts_container::add_script(script);
     let mut hash = ManuallyDrop::new(hash);
@@ -821,7 +824,14 @@ pub unsafe extern "C-unwind" fn create_client(
     client_type: *const ClientType,
     pubsub_callback: PubSubCallback,
 ) -> *const ConnectionResponse {
-    assert!(!connection_request_bytes.is_null());
+    if connection_request_bytes.is_null() {
+        return Box::into_raw(Box::new(ConnectionResponse {
+            conn_ptr: std::ptr::null(),
+            connection_error_message: CString::into_raw(
+                CString::new("Connection request bytes pointer is null").unwrap(),
+            ),
+        }));
+    }
     let request_bytes =
         unsafe { std::slice::from_raw_parts(connection_request_bytes, connection_request_len) };
     let client_type = unsafe { &*client_type };
@@ -1182,6 +1192,12 @@ pub unsafe extern "C-unwind" fn command(
     route_bytes_len: usize,
     span_ptr: u64,
 ) -> *mut CommandResult {
+    if client_adapter_ptr.is_null() {
+        return create_error_result_with_custom_error(
+            "Client adapter pointer is null".to_string(),
+            RequestErrorType::Unspecified,
+        );
+    }
     let client_adapter = unsafe {
         // we increment the strong count to ensure that the client is not dropped just because we turned it into an Arc.
         Arc::increment_strong_count(client_adapter_ptr);
@@ -1486,11 +1502,23 @@ pub unsafe extern "C-unwind" fn request_cluster_scan(
     args: *const usize,
     args_len: *const c_ulong,
 ) -> *mut CommandResult {
+    if client_adapter_ptr.is_null() {
+        return create_error_result_with_custom_error(
+            "Client adapter pointer is null".to_string(),
+            RequestErrorType::Unspecified,
+        );
+    }
     let client_adapter = unsafe {
         // we increment the strong count to ensure that the client is not dropped just because we turned it into an Arc.
         Arc::increment_strong_count(client_adapter_ptr);
         Arc::from_raw(client_adapter_ptr as *mut ClientAdapter)
     };
+
+    if cursor.is_null() {
+        let err = RedisError::from((ErrorKind::ClientError, "Cursor pointer is null"));
+        return unsafe { client_adapter.handle_redis_error(err, request_id) };
+    }
+
     let cursor_id = unsafe { CStr::from_ptr(cursor) }
         .to_str()
         .unwrap_or("0")
@@ -1655,11 +1683,22 @@ pub unsafe extern "C-unwind" fn update_connection_password(
     password: *const c_char,
     immediate_auth: bool,
 ) -> *mut CommandResult {
+    if client_adapter_ptr.is_null() {
+        return create_error_result_with_custom_error(
+            "Client adapter pointer is null".to_string(),
+            RequestErrorType::Unspecified,
+        );
+    }
     let client_adapter = unsafe {
         // we increment the strong count to ensure that the client is not dropped just because we turned it into an Arc.
         Arc::increment_strong_count(client_adapter_ptr);
         Arc::from_raw(client_adapter_ptr as *mut ClientAdapter)
     };
+
+    if password.is_null() {
+        let err = RedisError::from((ErrorKind::ClientError, "Password pointer is null"));
+        return unsafe { client_adapter.handle_redis_error(err, request_id) };
+    }
 
     // argument conversion to be used in the async block
     let password = match unsafe { CStr::from_ptr(password).to_str() } {
@@ -1709,6 +1748,12 @@ pub unsafe extern "C-unwind" fn refresh_iam_token(
     client_adapter_ptr: *const c_void,
     request_id: usize,
 ) -> *mut CommandResult {
+    if client_adapter_ptr.is_null() {
+        return create_error_result_with_custom_error(
+            "Client adapter pointer is null".to_string(),
+            RequestErrorType::Unspecified,
+        );
+    }
     let client_adapter = unsafe {
         // we increment the strong count to ensure that the client is not dropped just because we turned it into an Arc.
         Arc::increment_strong_count(client_adapter_ptr);
@@ -1769,11 +1814,22 @@ pub unsafe extern "C-unwind" fn invoke_script(
     route_bytes: *const u8,
     route_bytes_len: usize,
 ) -> *mut CommandResult {
+    if client_adapter_ptr.is_null() {
+        return create_error_result_with_custom_error(
+            "Client adapter pointer is null".to_string(),
+            RequestErrorType::Unspecified,
+        );
+    }
     let client_adapter = unsafe {
         // we increment the strong count to ensure that the client is not dropped just because we turned it into an Arc.
         Arc::increment_strong_count(client_adapter_ptr);
         Arc::from_raw(client_adapter_ptr as *mut ClientAdapter)
     };
+
+    if hash.is_null() {
+        let err = RedisError::from((ErrorKind::ClientError, "Script hash pointer is null"));
+        return unsafe { client_adapter.handle_redis_error(err, request_id) };
+    }
 
     // Convert hash to Rust string
     let hash_str = match unsafe { CStr::from_ptr(hash).to_str() } {
@@ -1918,11 +1974,29 @@ pub unsafe extern "C" fn batch(
     options_ptr: *const BatchOptionsInfo,
     span_ptr: u64,
 ) -> *mut CommandResult {
+    if client_ptr.is_null() {
+        return create_error_result_with_custom_error(
+            "Client adapter pointer is null".to_string(),
+            RequestErrorType::Unspecified,
+        );
+    }
     let client_adapter = unsafe {
         // we increment the strong count to ensure that the client is not dropped just because we turned it into an Arc.
         Arc::increment_strong_count(client_ptr);
         Arc::from_raw(client_ptr as *mut ClientAdapter)
     };
+
+    if batch_ptr.is_null() {
+        let err = "Batch info pointer is null".to_string();
+        return unsafe {
+            client_adapter.handle_custom_error(
+                err,
+                RequestErrorType::Unspecified,
+                callback_index,
+            )
+        };
+    }
+
     let mut client = client_adapter.core.client.clone();
 
     // Get compression manager for batch operations

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1989,11 +1989,7 @@ pub unsafe extern "C" fn batch(
     if batch_ptr.is_null() {
         let err = "Batch info pointer is null".to_string();
         return unsafe {
-            client_adapter.handle_custom_error(
-                err,
-                RequestErrorType::Unspecified,
-                callback_index,
-            )
+            client_adapter.handle_custom_error(err, RequestErrorType::Unspecified, callback_index)
         };
     }
 

--- a/ffi/tests/test_null_checks.rs
+++ b/ffi/tests/test_null_checks.rs
@@ -1,6 +1,17 @@
 use glide_core::request_type::RequestType;
 use glide_ffi::*;
-use std::ffi::{c_char, c_void, CString};
+
+unsafe extern "C-unwind" fn dummy_callback(
+    _client_ptr: usize,
+    _kind: PushKind,
+    _message: *const u8,
+    _message_len: i64,
+    _channel: *const u8,
+    _channel_len: i64,
+    _pattern: *const u8,
+    _pattern_len: i64,
+) {
+}
 
 #[test]
 fn test_store_script_null() {
@@ -11,17 +22,23 @@ fn test_store_script_null() {
 #[test]
 fn test_create_client_null() {
     let client_type = Box::into_raw(Box::new(ClientType::SyncClient));
-    let res = unsafe { create_client(std::ptr::null(), 0, client_type, std::mem::transmute(0usize)) };
+    let res = unsafe { create_client(std::ptr::null(), 0, client_type, dummy_callback) };
     assert!(!res.is_null());
     let response = unsafe { res.as_ref() }.expect("response is null");
     assert!(response.conn_ptr.is_null());
     assert!(!response.connection_error_message.is_null());
 
-    let err_msg = unsafe { std::ffi::CStr::from_ptr(response.connection_error_message).to_str().unwrap() };
+    let err_msg = unsafe {
+        std::ffi::CStr::from_ptr(response.connection_error_message)
+            .to_str()
+            .unwrap()
+    };
     assert!(err_msg.contains("Connection request bytes pointer is null"));
 
     unsafe { free_connection_response(res as *mut ConnectionResponse) };
-    unsafe { let _ = Box::from_raw(client_type); }
+    unsafe {
+        let _ = Box::from_raw(client_type);
+    }
 }
 
 #[test]
@@ -38,7 +55,7 @@ fn test_invoke_script_null_client() {
             std::ptr::null(),
             std::ptr::null(),
             std::ptr::null(),
-            0
+            0,
         )
     };
     assert!(!res.is_null());
@@ -47,7 +64,11 @@ fn test_invoke_script_null_client() {
     assert!(!result.command_error.is_null());
 
     let error = unsafe { result.command_error.as_ref() }.expect("command_error is null");
-    let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
+    let err_msg = unsafe {
+        std::ffi::CStr::from_ptr(error.command_error_message)
+            .to_str()
+            .unwrap()
+    };
     assert!(err_msg.contains("Client adapter pointer is null"));
 
     unsafe { free_command_result(res) };
@@ -65,7 +86,7 @@ fn test_command_null_client() {
             std::ptr::null(),
             std::ptr::null(),
             0,
-            0
+            0,
         )
     };
     assert!(!res.is_null());
@@ -74,7 +95,11 @@ fn test_command_null_client() {
     assert!(!result.command_error.is_null());
 
     let error = unsafe { result.command_error.as_ref() }.expect("command_error is null");
-    let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
+    let err_msg = unsafe {
+        std::ffi::CStr::from_ptr(error.command_error_message)
+            .to_str()
+            .unwrap()
+    };
     assert!(err_msg.contains("Client adapter pointer is null"));
 
     unsafe { free_command_result(res) };
@@ -98,7 +123,11 @@ fn test_request_cluster_scan_null_client() {
     assert!(!result.command_error.is_null());
 
     let error = unsafe { result.command_error.as_ref() }.expect("command_error is null");
-    let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
+    let err_msg = unsafe {
+        std::ffi::CStr::from_ptr(error.command_error_message)
+            .to_str()
+            .unwrap()
+    };
     assert!(err_msg.contains("Client adapter pointer is null"));
 
     unsafe { free_command_result(res) };
@@ -106,21 +135,18 @@ fn test_request_cluster_scan_null_client() {
 
 #[test]
 fn test_update_connection_password_null_client() {
-    let res = unsafe {
-        update_connection_password(
-            std::ptr::null(),
-            0,
-            std::ptr::null(),
-            false
-        )
-    };
+    let res = unsafe { update_connection_password(std::ptr::null(), 0, std::ptr::null(), false) };
     assert!(!res.is_null());
     let result = unsafe { res.as_ref() }.expect("result is null");
     assert!(result.response.is_null());
     assert!(!result.command_error.is_null());
 
     let error = unsafe { result.command_error.as_ref() }.expect("command_error is null");
-    let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
+    let err_msg = unsafe {
+        std::ffi::CStr::from_ptr(error.command_error_message)
+            .to_str()
+            .unwrap()
+    };
     assert!(err_msg.contains("Client adapter pointer is null"));
 
     unsafe { free_command_result(res) };
@@ -128,19 +154,18 @@ fn test_update_connection_password_null_client() {
 
 #[test]
 fn test_refresh_iam_token_null_client() {
-    let res = unsafe {
-        refresh_iam_token(
-            std::ptr::null(),
-            0,
-        )
-    };
+    let res = unsafe { refresh_iam_token(std::ptr::null(), 0) };
     assert!(!res.is_null());
     let result = unsafe { res.as_ref() }.expect("result is null");
     assert!(result.response.is_null());
     assert!(!result.command_error.is_null());
 
     let error = unsafe { result.command_error.as_ref() }.expect("command_error is null");
-    let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
+    let err_msg = unsafe {
+        std::ffi::CStr::from_ptr(error.command_error_message)
+            .to_str()
+            .unwrap()
+    };
     assert!(err_msg.contains("Client adapter pointer is null"));
 
     unsafe { free_command_result(res) };
@@ -155,7 +180,7 @@ fn test_batch_null_client() {
             std::ptr::null(),
             false,
             std::ptr::null(),
-            0
+            0,
         )
     };
     assert!(!res.is_null());
@@ -164,7 +189,11 @@ fn test_batch_null_client() {
     assert!(!result.command_error.is_null());
 
     let error = unsafe { result.command_error.as_ref() }.expect("command_error is null");
-    let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
+    let err_msg = unsafe {
+        std::ffi::CStr::from_ptr(error.command_error_message)
+            .to_str()
+            .unwrap()
+    };
     assert!(err_msg.contains("Client adapter pointer is null"));
 
     unsafe { free_command_result(res) };

--- a/ffi/tests/test_null_checks.rs
+++ b/ffi/tests/test_null_checks.rs
@@ -1,0 +1,171 @@
+use glide_core::request_type::RequestType;
+use glide_ffi::*;
+use std::ffi::{c_char, c_void, CString};
+
+#[test]
+fn test_store_script_null() {
+    let res = unsafe { store_script(std::ptr::null(), 0) };
+    assert!(res.is_null());
+}
+
+#[test]
+fn test_create_client_null() {
+    let client_type = Box::into_raw(Box::new(ClientType::SyncClient));
+    let res = unsafe { create_client(std::ptr::null(), 0, client_type, std::mem::transmute(0usize)) };
+    assert!(!res.is_null());
+    let response = unsafe { &*res };
+    assert!(response.conn_ptr.is_null());
+    assert!(!response.connection_error_message.is_null());
+
+    let err_msg = unsafe { std::ffi::CStr::from_ptr(response.connection_error_message).to_str().unwrap() };
+    assert!(err_msg.contains("Connection request bytes pointer is null"));
+
+    unsafe { free_connection_response(res as *mut ConnectionResponse) };
+    unsafe { let _ = Box::from_raw(client_type); }
+}
+
+#[test]
+fn test_invoke_script_null_client() {
+    let res = unsafe {
+        invoke_script(
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            0
+        )
+    };
+    assert!(!res.is_null());
+    let result = unsafe { &*res };
+    assert!(result.response.is_null());
+    assert!(!result.command_error.is_null());
+
+    let error = unsafe { &*result.command_error };
+    let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
+    assert!(err_msg.contains("Client adapter pointer is null"));
+
+    unsafe { free_command_result(res) };
+}
+
+#[test]
+fn test_command_null_client() {
+    let res = unsafe {
+        command(
+            std::ptr::null(),
+            0,
+            RequestType::Ping,
+            0,
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            0,
+            0
+        )
+    };
+    assert!(!res.is_null());
+    let result = unsafe { &*res };
+    assert!(result.response.is_null());
+    assert!(!result.command_error.is_null());
+
+    let error = unsafe { &*result.command_error };
+    let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
+    assert!(err_msg.contains("Client adapter pointer is null"));
+
+    unsafe { free_command_result(res) };
+}
+
+#[test]
+fn test_request_cluster_scan_null_client() {
+    let res = unsafe {
+        request_cluster_scan(
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            std::ptr::null(),
+        )
+    };
+    assert!(!res.is_null());
+    let result = unsafe { &*res };
+    assert!(result.response.is_null());
+    assert!(!result.command_error.is_null());
+
+    let error = unsafe { &*result.command_error };
+    let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
+    assert!(err_msg.contains("Client adapter pointer is null"));
+
+    unsafe { free_command_result(res) };
+}
+
+#[test]
+fn test_update_connection_password_null_client() {
+    let res = unsafe {
+        update_connection_password(
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            false
+        )
+    };
+    assert!(!res.is_null());
+    let result = unsafe { &*res };
+    assert!(result.response.is_null());
+    assert!(!result.command_error.is_null());
+
+    let error = unsafe { &*result.command_error };
+    let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
+    assert!(err_msg.contains("Client adapter pointer is null"));
+
+    unsafe { free_command_result(res) };
+}
+
+#[test]
+fn test_refresh_iam_token_null_client() {
+    let res = unsafe {
+        refresh_iam_token(
+            std::ptr::null(),
+            0,
+        )
+    };
+    assert!(!res.is_null());
+    let result = unsafe { &*res };
+    assert!(result.response.is_null());
+    assert!(!result.command_error.is_null());
+
+    let error = unsafe { &*result.command_error };
+    let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
+    assert!(err_msg.contains("Client adapter pointer is null"));
+
+    unsafe { free_command_result(res) };
+}
+
+#[test]
+fn test_batch_null_client() {
+    let res = unsafe {
+        batch(
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            false,
+            std::ptr::null(),
+            0
+        )
+    };
+    assert!(!res.is_null());
+    let result = unsafe { &*res };
+    assert!(result.response.is_null());
+    assert!(!result.command_error.is_null());
+
+    let error = unsafe { &*result.command_error };
+    let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
+    assert!(err_msg.contains("Client adapter pointer is null"));
+
+    unsafe { free_command_result(res) };
+}

--- a/ffi/tests/test_null_checks.rs
+++ b/ffi/tests/test_null_checks.rs
@@ -13,7 +13,7 @@ fn test_create_client_null() {
     let client_type = Box::into_raw(Box::new(ClientType::SyncClient));
     let res = unsafe { create_client(std::ptr::null(), 0, client_type, std::mem::transmute(0usize)) };
     assert!(!res.is_null());
-    let response = unsafe { &*res };
+    let response = unsafe { res.as_ref() }.expect("response is null");
     assert!(response.conn_ptr.is_null());
     assert!(!response.connection_error_message.is_null());
 
@@ -42,11 +42,11 @@ fn test_invoke_script_null_client() {
         )
     };
     assert!(!res.is_null());
-    let result = unsafe { &*res };
+    let result = unsafe { res.as_ref() }.expect("result is null");
     assert!(result.response.is_null());
     assert!(!result.command_error.is_null());
 
-    let error = unsafe { &*result.command_error };
+    let error = unsafe { result.command_error.as_ref() }.expect("command_error is null");
     let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
     assert!(err_msg.contains("Client adapter pointer is null"));
 
@@ -69,11 +69,11 @@ fn test_command_null_client() {
         )
     };
     assert!(!res.is_null());
-    let result = unsafe { &*res };
+    let result = unsafe { res.as_ref() }.expect("result is null");
     assert!(result.response.is_null());
     assert!(!result.command_error.is_null());
 
-    let error = unsafe { &*result.command_error };
+    let error = unsafe { result.command_error.as_ref() }.expect("command_error is null");
     let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
     assert!(err_msg.contains("Client adapter pointer is null"));
 
@@ -93,11 +93,11 @@ fn test_request_cluster_scan_null_client() {
         )
     };
     assert!(!res.is_null());
-    let result = unsafe { &*res };
+    let result = unsafe { res.as_ref() }.expect("result is null");
     assert!(result.response.is_null());
     assert!(!result.command_error.is_null());
 
-    let error = unsafe { &*result.command_error };
+    let error = unsafe { result.command_error.as_ref() }.expect("command_error is null");
     let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
     assert!(err_msg.contains("Client adapter pointer is null"));
 
@@ -115,11 +115,11 @@ fn test_update_connection_password_null_client() {
         )
     };
     assert!(!res.is_null());
-    let result = unsafe { &*res };
+    let result = unsafe { res.as_ref() }.expect("result is null");
     assert!(result.response.is_null());
     assert!(!result.command_error.is_null());
 
-    let error = unsafe { &*result.command_error };
+    let error = unsafe { result.command_error.as_ref() }.expect("command_error is null");
     let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
     assert!(err_msg.contains("Client adapter pointer is null"));
 
@@ -135,11 +135,11 @@ fn test_refresh_iam_token_null_client() {
         )
     };
     assert!(!res.is_null());
-    let result = unsafe { &*res };
+    let result = unsafe { res.as_ref() }.expect("result is null");
     assert!(result.response.is_null());
     assert!(!result.command_error.is_null());
 
-    let error = unsafe { &*result.command_error };
+    let error = unsafe { result.command_error.as_ref() }.expect("command_error is null");
     let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
     assert!(err_msg.contains("Client adapter pointer is null"));
 
@@ -159,11 +159,11 @@ fn test_batch_null_client() {
         )
     };
     assert!(!res.is_null());
-    let result = unsafe { &*res };
+    let result = unsafe { res.as_ref() }.expect("result is null");
     assert!(result.response.is_null());
     assert!(!result.command_error.is_null());
 
-    let error = unsafe { &*result.command_error };
+    let error = unsafe { result.command_error.as_ref() }.expect("command_error is null");
     let err_msg = unsafe { std::ffi::CStr::from_ptr(error.command_error_message).to_str().unwrap() };
     assert!(err_msg.contains("Client adapter pointer is null"));
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential Undefined Behavior (UB) and crashes due to missing null pointer checks in FFI functions exposed to foreign languages (C, Python, Node.js, Go). Functions like `store_script`, `create_client`, and `command` dereferenced raw pointers (e.g., via `std::slice::from_raw_parts` or `CStr::from_ptr`) without verifying they were non-null.
🎯 Impact: Calling these functions with null pointers (e.g., due to bugs in binding code or misuse) would cause the application to crash (segfault) or exhibit undefined behavior, which is a security risk (DoS).
🔧 Fix: Added explicit `is_null()` checks at the beginning of `extern "C"` functions.
  - `store_script`: Returns null pointer if input is null.
  - `create_client`: Returns `ConnectionResponse` with error message.
  - `command`, `invoke_script`, `request_cluster_scan`, `update_connection_password`, `refresh_iam_token`, `batch`: Returns `CommandResult` with error message.
✅ Verification: Added `ffi/tests/test_null_checks.rs` which calls these functions with null pointers and asserts that they return appropriate error indicators instead of crashing. Verified by running `cargo test --package glide-ffi --test test_null_checks`.

---
*PR created automatically by Jules for task [17591675172365807427](https://jules.google.com/task/17591675172365807427) started by @avifenesh*