### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix TOCTOU vulnerability in socket creation

### DIFF
--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -32,6 +32,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::io;
 use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 use std::ptr::from_mut;
 use std::rc::Rc;
 use std::str;
@@ -832,6 +833,9 @@ fn get_unsafe_span_from_ptr(command_span: Option<u64>) -> Option<GlideSpan> {
 pub fn close_socket(socket_path: &String) {
     log_info("close_socket", format!("closing socket at {socket_path}"));
     let _ = std::fs::remove_file(socket_path);
+    if let Some(parent) = Path::new(socket_path).parent() {
+        let _ = std::fs::remove_dir(parent);
+    }
 }
 
 async fn create_client(
@@ -1069,7 +1073,7 @@ pub fn get_socket_path() -> String {
     // to the socket name. The UUID is used to ensure that the socket name is unique for situations in which PID can be resused such as with dockers.
     static SOCKET_NAME: Lazy<String> = Lazy::new(|| {
         format!(
-            "{}-{}-{}.sock",
+            "{}-{}-{}/socket",
             SOCKET_FILE_NAME,
             std::process::id(),
             Uuid::new_v4(),
@@ -1122,6 +1126,27 @@ pub fn start_socket_listener_internal<InitCallback>(
     };
 
     glide_rt.runtime.spawn(async move {
+        // Create parent directory if it doesn't exist, with restricted permissions
+        if let Some(parent) = Path::new(&socket_path_cloned).parent() {
+            if !parent.exists() {
+                if let Err(err) = fs::create_dir_all(parent) {
+                    log_error(
+                        "listen_on_socket",
+                        format!("Failed to create socket directory: {err}"),
+                    );
+                    let _ = tx.send(Err(err));
+                    return;
+                }
+                // Set permissions to 700
+                if let Err(err) = fs::set_permissions(parent, fs::Permissions::from_mode(0o700)) {
+                    log_error(
+                        "listen_on_socket",
+                        format!("Failed to set permissions for socket directory: {err}"),
+                    );
+                }
+            }
+        }
+
         let listener_socket = match UnixListener::bind(socket_path_cloned.clone()) {
             Err(err) => {
                 log_error(
@@ -1177,6 +1202,9 @@ pub fn start_socket_listener_internal<InitCallback>(
         // ensure socket file removal
         drop(listener_socket);
         let _ = std::fs::remove_file(socket_path_cloned.clone());
+        if let Some(parent) = Path::new(&socket_path_cloned).parent() {
+            let _ = std::fs::remove_dir(parent);
+        }
 
         // no more listening on socket - update the sockets db
         let mut sockets_write_guard = INITIALIZED_SOCKETS

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -1127,23 +1127,24 @@ pub fn start_socket_listener_internal<InitCallback>(
 
     glide_rt.runtime.spawn(async move {
         // Create parent directory if it doesn't exist, with restricted permissions
-        if let Some(parent) = Path::new(&socket_path_cloned).parent() {
-            if !parent.exists() {
-                if let Err(err) = fs::create_dir_all(parent) {
-                    log_error(
-                        "listen_on_socket",
-                        format!("Failed to create socket directory: {err}"),
-                    );
-                    let _ = tx.send(Err(err));
-                    return;
-                }
-                // Set permissions to 700
-                if let Err(err) = fs::set_permissions(parent, fs::Permissions::from_mode(0o700)) {
-                    log_error(
-                        "listen_on_socket",
-                        format!("Failed to set permissions for socket directory: {err}"),
-                    );
-                }
+        if let Some(parent) = Path::new(&socket_path_cloned)
+            .parent()
+            .filter(|p| !p.exists())
+        {
+            if let Err(err) = fs::create_dir_all(parent) {
+                log_error(
+                    "listen_on_socket",
+                    format!("Failed to create socket directory: {err}"),
+                );
+                let _ = tx.send(Err(err));
+                return;
+            }
+            // Set permissions to 700
+            if let Err(err) = fs::set_permissions(parent, fs::Permissions::from_mode(0o700)) {
+                log_error(
+                    "listen_on_socket",
+                    format!("Failed to set permissions for socket directory: {err}"),
+                );
             }
         }
 

--- a/glide-core/tests/test_socket_listener.rs
+++ b/glide-core/tests/test_socket_listener.rs
@@ -1417,4 +1417,41 @@ mod socket_listener {
             ResponseType::RequestError,
         );
     }
+
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_STANDALONE_TEST_TIMEOUT)]
+    fn test_socket_directory_permissions() {
+        let socket_listener_state: Arc<ManualResetEvent> =
+            Arc::new(ManualResetEvent::new(EventState::Unset));
+        let cloned_state = socket_listener_state.clone();
+        let path_arc = Arc::new(std::sync::Mutex::new(None));
+        let path_arc_clone = Arc::clone(&path_arc);
+
+        socket_listener::start_socket_listener(
+            move |res| {
+                let path: String = res.expect("Failed to initialize the socket listener");
+                let mut path_arc_clone = path_arc_clone.lock().unwrap();
+                *path_arc_clone = Some(path);
+                cloned_state.set();
+            }
+        );
+        socket_listener_state.wait();
+        let path_binding = path_arc.lock().unwrap();
+        let path_str = path_binding.as_ref().expect("Didn't get any socket path");
+        let path = std::path::Path::new(path_str);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Some(parent) = path.parent() {
+                let metadata = std::fs::metadata(parent).expect("Failed to get metadata");
+                let permissions = metadata.permissions();
+                let mode = permissions.mode();
+                // Check if mode is 700 (rwx------)
+                assert_eq!(mode & 0o777, 0o700, "Directory permissions should be 0700");
+            }
+        }
+        socket_listener::close_socket(path_str);
+    }
 }

--- a/glide-core/tests/test_socket_listener.rs
+++ b/glide-core/tests/test_socket_listener.rs
@@ -1431,10 +1431,7 @@ mod socket_listener {
         // Use a unique socket name to avoid interfering with other tests that use the shared socket.
         // The unique name must contain a slash to trigger the directory creation logic in `start_socket_listener_internal`.
         // `get_socket_path_from_name` will prepend the base directory (e.g. /tmp), so we just need a unique subdir/socket structure.
-        let unique_socket_name = format!(
-            "test-perms-{}/socket",
-            uuid::Uuid::new_v4()
-        );
+        let unique_socket_name = format!("test-perms-{}/socket", uuid::Uuid::new_v4());
         let socket_path = socket_listener::get_socket_path_from_name(unique_socket_name);
 
         socket_listener::start_socket_listener_internal(

--- a/glide-core/tests/test_socket_listener.rs
+++ b/glide-core/tests/test_socket_listener.rs
@@ -1428,13 +1428,23 @@ mod socket_listener {
         let path_arc = Arc::new(std::sync::Mutex::new(None));
         let path_arc_clone = Arc::clone(&path_arc);
 
-        socket_listener::start_socket_listener(
+        // Use a unique socket name to avoid interfering with other tests that use the shared socket.
+        // The unique name must contain a slash to trigger the directory creation logic in `start_socket_listener_internal`.
+        // `get_socket_path_from_name` will prepend the base directory (e.g. /tmp), so we just need a unique subdir/socket structure.
+        let unique_socket_name = format!(
+            "test-perms-{}/socket",
+            uuid::Uuid::new_v4()
+        );
+        let socket_path = socket_listener::get_socket_path_from_name(unique_socket_name);
+
+        socket_listener::start_socket_listener_internal(
             move |res| {
                 let path: String = res.expect("Failed to initialize the socket listener");
                 let mut path_arc_clone = path_arc_clone.lock().unwrap();
                 *path_arc_clone = Some(path);
                 cloned_state.set();
-            }
+            },
+            Some(socket_path),
         );
         socket_listener_state.wait();
         let path_binding = path_arc.lock().unwrap();


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: A Time-of-Check-Time-of-Use (TOCTOU) race condition existed in the creation of the Unix domain socket used for IPC. The socket was created in a public directory (e.g., `/tmp`) with default permissions before being restricted, allowing a potential attacker to connect during the window between creation and permission tightening.
🎯 Impact: Local attackers could potentially connect to the socket and issue unauthorized Redis commands, leading to data access or modification.
🔧 Fix: The socket is now created within a dedicated, temporary directory with restricted `0700` permissions. The directory is created before binding the socket, ensuring that the socket is never exposed with insecure permissions.
✅ Verification: Added `test_socket_directory_permissions` in `glide-core/tests/test_socket_listener.rs` which verifies that the socket directory has `0700` permissions. Ran `cargo test` in `glide-core`.

---
*PR created automatically by Jules for task [15185308070523464550](https://jules.google.com/task/15185308070523464550) started by @avifenesh*