### PR TITLE
[pub-agent] chore(tooling): add unified developer toolkit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,30 +35,54 @@ This is the Valkey GLIDE mono-repository containing a Rust core (`glide-core`) a
 
 ## Build and Test Rules (Agents)
 
-### Preferred (Make Targets)
+### Developer Toolkit (Recommended)
+```bash
+# Unified developer CLI - use this for most operations
+./dev.sh setup          # Verify all toolchain prerequisites
+./dev.sh status         # Show branch, toolchain versions, changed languages
+./dev.sh check          # Pre-push: auto-detect changed languages, lint + build
+./dev.sh check rust     # Pre-push: validate only Rust
+./dev.sh fmt java       # Format only Java code
+./dev.sh lint python    # Lint only Python code
+./dev.sh build node     # Build only Node.js client
+./dev.sh test go        # Run Go unit tests
+./dev.sh changed        # Show which languages have changes vs main
+```
+
+### Make Targets
 ```bash
 # Build all language bindings
 make all
 
 # Individual language builds
+make rust          # Build Rust core (release mode)
 make java          # Build Java client (release mode)
 make python        # Build Python async + sync clients (release mode)
 make node          # Build Node.js client (release mode)
 make go            # Build Go client
 
 # Testing
+make rust-test     # Run Rust core unit tests
 make java-test     # Run Java integration tests
 make python-test   # Run Python tests
 make node-test     # Run Node.js tests
 make go-test       # Run Go tests
 
 # Linting
+make rust-lint     # Run Rust clippy + format check
 make java-lint     # Run Java spotlessApply
 make python-lint   # Run Python linters via dev.py
 make node-lint     # Run Node.js linters
 make go-lint       # Run Go linters
 
+# Cross-language
+make check         # Pre-push validation (via dev.sh)
+make status        # Show repo status
+make lint-all      # Lint all languages
+make fmt-all       # Format all languages
+
 # Utilities
+make rust-fmt      # Format Rust code
 make clean         # Remove .build/ directory
 make help          # List available targets
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,119 @@ docs/           # Documentation
 Socket IPC wrappers → `socket_listener` → `glide-core` → Valkey/Redis
 FFI wrappers → `glide-core` → Valkey/Redis
 
+## Developer Toolkit (`./dev.sh`)
+
+Unified CLI for cross-language development. Use this instead of remembering per-language commands.
+
+```bash
+./dev.sh setup          # Verify all toolchain prerequisites are installed
+./dev.sh status         # Show branch, toolchain versions, changed languages
+./dev.sh changed        # Show which languages have changes vs main
+./dev.sh check          # Pre-push: auto-detect changed languages, lint + build
+./dev.sh check rust     # Pre-push: validate only Rust
+./dev.sh fmt java       # Format only Java code
+./dev.sh lint python    # Lint only Python code
+./dev.sh build node     # Build only Node.js client
+./dev.sh test go        # Run Go unit tests
+```
+
+## Command Quick Reference
+
+<command-reference>
+  <lang name="rust">
+    <build>cargo build --release</build>
+    <test>cd glide-core &amp;&amp; cargo test</test>
+    <lint>cargo clippy --all-targets -- -D warnings</lint>
+    <format>cargo fmt --all</format>
+    <bench>cd glide-core &amp;&amp; cargo bench</bench>
+  </lang>
+  <lang name="java">
+    <build>cd java &amp;&amp; ./gradlew :client:buildAllRelease</build>
+    <test>cd java &amp;&amp; ./gradlew :integTest:test</test>
+    <lint>cd java &amp;&amp; ./gradlew :spotlessCheck</lint>
+    <format>cd java &amp;&amp; ./gradlew :spotlessApply</format>
+  </lang>
+  <lang name="python">
+    <build>cd python &amp;&amp; python3 dev.py build --mode release</build>
+    <test>cd python &amp;&amp; python3 dev.py test</test>
+    <lint>cd python &amp;&amp; python3 dev.py lint</lint>
+  </lang>
+  <lang name="node">
+    <build>cd node &amp;&amp; npm run build:release</build>
+    <test>cd node &amp;&amp; npm test</test>
+    <lint>cd node &amp;&amp; npx eslint .</lint>
+    <format>cd node &amp;&amp; npx prettier --write src/ tests/</format>
+  </lang>
+  <lang name="go">
+    <build>cd go &amp;&amp; make build</build>
+    <test>cd go &amp;&amp; make unit-test</test>
+    <integ-test>cd go &amp;&amp; make integ-test</integ-test>
+    <lint>cd go &amp;&amp; make lint</lint>
+    <format>cd go &amp;&amp; make format</format>
+  </lang>
+</command-reference>
+
+## Workflow Recipes
+
+<workflows>
+  <workflow name="adding-a-new-command">
+    <description>Adding a new Valkey command to a language binding</description>
+    <steps>
+      1. Check if command exists in glide-core (grep for command name in glide-core/src/)
+      2. If not in core: add to protobuf enum in glide-core/src/protobuf/command_request.proto
+      3. Add command handling in glide-core/src/client/mod.rs
+      4. Add language-specific wrapper (see context-sources for file paths)
+      5. Add tests (unit + integration) in the language's test directory
+      6. Run ./dev.sh check [language] before committing
+    </steps>
+  </workflow>
+  <workflow name="core-change-impact">
+    <description>When modifying glide-core, assess cross-language impact</description>
+    <steps>
+      1. Identify if change affects socket_listener.rs (impacts Python async, Node.js)
+      2. Identify if change affects ffi/ (impacts Python sync, Go)
+      3. Identify if change affects JNI interface (impacts Java)
+      4. Run ./dev.sh check to validate all affected bindings
+      5. Update protobuf definitions if command/response shapes changed
+    </steps>
+  </workflow>
+  <workflow name="debugging-integration-tests">
+    <description>When integration tests fail</description>
+    <steps>
+      1. Ensure valkey-server or redis-server is running (./dev.sh setup checks this)
+      2. For cluster tests: python3 utils/cluster_manager.py start --cluster-mode
+      3. For standalone tests: python3 utils/cluster_manager.py start
+      4. Check server logs for connection issues
+      5. Set RUST_LOG=debug for verbose core logging
+    </steps>
+  </workflow>
+</workflows>
+
+## Troubleshooting
+
+<troubleshooting>
+  <issue trigger="cargo build fails with protobuf error">
+    Run: protoc --version (need v3+). Install: apt install protobuf-compiler or brew install protobuf
+  </issue>
+  <issue trigger="Python build fails with maturin/PyO3 error">
+    Ensure virtual env is active. Run: cd python && python3 dev.py build --mode debug for verbose output
+  </issue>
+  <issue trigger="Node.js build fails with NAPI error">
+    Run: cd node && npm i && cd rust-client && npm i (reinstall native deps)
+  </issue>
+  <issue trigger="Go build fails with CGO/FFI error">
+    Ensure libglide_ffi.a exists. Run: cd go && make build-glide-client (builds FFI first)
+  </issue>
+  <issue trigger="Java build fails with JNI linking">
+    Check JAVA_HOME is set. Run: cd java && ./gradlew :client:buildAllRelease (builds Rust JNI lib)
+  </issue>
+  <issue trigger="Integration tests can't connect to server">
+    Start server: python3 utils/cluster_manager.py start
+    For cluster mode: python3 utils/cluster_manager.py start --cluster-mode
+    Stop all: python3 utils/cluster_manager.py stop --prefix cluster
+  </issue>
+</troubleshooting>
+
 ## Context Retrieval
 
 <context-sources>

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all java java-test python python-test node node-test check-valkey-server go go-test prettier-check prettier-fix
+.PHONY: all java java-test python python-test node node-test check-valkey-server go go-test prettier-check prettier-fix rust rust-test rust-lint rust-fmt check status
 
 BLUE=\033[34m
 YELLOW=\033[33m
@@ -100,6 +100,42 @@ go-lint: .build/go_deps
 	@mkdir -p .build/ && touch .build/go_deps
 
 ##
+## Rust targets
+##
+rust:
+	@echo "$(GREEN)Building Rust core (release)$(RESET)"
+	@cargo build --release
+
+rust-test:
+	@echo "$(GREEN)Running Rust core tests$(RESET)"
+	@cd glide-core && cargo test
+
+rust-lint:
+	@echo "$(GREEN)Running Rust linters (clippy + fmt check)$(RESET)"
+	@cargo clippy --all-targets -- -D warnings
+	@cargo fmt --all -- --check
+
+rust-fmt:
+	@echo "$(GREEN)Formatting Rust code$(RESET)"
+	@cargo fmt --all
+
+##
+## Cross-language targets
+##
+check:
+	@echo "$(GREEN)Running pre-push checks via dev.sh$(RESET)"
+	@./dev.sh check
+
+status:
+	@./dev.sh status
+
+fmt-all: rust-fmt java-lint python-lint
+	@echo "$(GREEN)All formatters completed$(RESET)"
+
+lint-all: rust-lint java-lint python-lint node-lint go-lint
+	@echo "$(GREEN)All linters completed$(RESET)"
+
+##
 ## Common targets
 ##
 check-valkey-server:
@@ -109,5 +145,14 @@ clean:
 	rm -fr .build/
 
 help:
-	@echo "$(GREEN)Listing Makefile targets:$(RESET)"
-	@echo $(shell grep '^[^#[:space:]].*:' Makefile|cut -d":" -f1|grep -v PHONY|grep -v "^.build"|sort)
+	@echo "$(GREEN)Valkey GLIDE Makefile Targets$(RESET)"
+	@echo ""
+	@echo "  $(YELLOW)Rust:$(RESET)     rust  rust-test  rust-lint  rust-fmt"
+	@echo "  $(YELLOW)Java:$(RESET)     java  java-test  java-lint"
+	@echo "  $(YELLOW)Python:$(RESET)   python  python-test  python-lint"
+	@echo "  $(YELLOW)Node.js:$(RESET)  node  node-test  node-lint"
+	@echo "  $(YELLOW)Go:$(RESET)       go  go-test  go-lint"
+	@echo "  $(YELLOW)Cross:$(RESET)    all  check  status  fmt-all  lint-all"
+	@echo "  $(YELLOW)Util:$(RESET)     clean  help  prettier-check  prettier-fix"
+	@echo ""
+	@echo "  Tip: use $(BLUE)./dev.sh$(RESET) for the full developer toolkit"

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,437 @@
+#!/usr/bin/env bash
+# Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+#
+# dev.sh - Unified developer toolkit for Valkey GLIDE
+#
+# Provides a single entry point for common cross-language operations:
+#   ./dev.sh status       - Show repo build/dependency status
+#   ./dev.sh check        - Pre-push validation (format + lint + build)
+#   ./dev.sh fmt [lang]   - Format code (all or specific language)
+#   ./dev.sh lint [lang]  - Lint code (all or specific language)
+#   ./dev.sh build [lang] - Build (all or specific language)
+#   ./dev.sh test [lang]  - Run tests (all or specific language)
+#   ./dev.sh setup        - Verify development environment
+#   ./dev.sh changed      - Show which languages have changes vs main
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+LANGUAGES=(rust java python node go)
+
+info()  { echo -e "${BLUE}[info]${RESET} $*"; }
+ok()    { echo -e "${GREEN}[ok]${RESET} $*"; }
+warn()  { echo -e "${YELLOW}[warn]${RESET} $*"; }
+err()   { echo -e "${RED}[error]${RESET} $*"; }
+header(){ echo -e "\n${BOLD}$*${RESET}"; }
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+check_tool() {
+    local tool=$1
+    if command -v "$tool" &>/dev/null; then
+        ok "$tool $(command -v "$tool")"
+        return 0
+    else
+        err "$tool not found"
+        return 1
+    fi
+}
+
+# Detect which languages have file changes compared to main branch
+detect_changed_languages() {
+    local base="${1:-main}"
+    local changed=()
+    local files
+    files=$(git diff --name-only "$base"...HEAD 2>/dev/null || git diff --name-only HEAD~1 2>/dev/null || echo "")
+
+    if [[ -z "$files" ]]; then
+        echo "${LANGUAGES[@]}"
+        return
+    fi
+
+    if echo "$files" | grep -qE '^(glide-core/|logger_core/|ffi/|Cargo)'; then
+        changed+=(rust)
+    fi
+    if echo "$files" | grep -qE '^java/'; then
+        changed+=(java)
+    fi
+    if echo "$files" | grep -qE '^python/'; then
+        changed+=(python)
+    fi
+    if echo "$files" | grep -qE '^node/'; then
+        changed+=(node)
+    fi
+    if echo "$files" | grep -qE '^go/'; then
+        changed+=(go)
+    fi
+
+    if [[ ${#changed[@]} -eq 0 ]]; then
+        echo "none"
+    else
+        echo "${changed[@]}"
+    fi
+}
+
+# ── Commands ─────────────────────────────────────────────────────────
+
+cmd_status() {
+    header "Repository Status"
+    echo -e "Branch: $(git branch --show-current)"
+    echo -e "Commit: $(git log --oneline -1)"
+    echo ""
+
+    header "Language Toolchain Versions"
+    echo -n "  Rust:   "; rustc --version 2>/dev/null || echo "not installed"
+    echo -n "  Cargo:  "; cargo --version 2>/dev/null || echo "not installed"
+    echo -n "  Java:   "; java --version 2>/dev/null | head -1 || echo "not installed"
+    echo -n "  Gradle: "; cd java 2>/dev/null && ./gradlew --version 2>/dev/null | grep "^Gradle " || echo "not available"; cd "$ROOT_DIR"
+    echo -n "  Python: "; python3 --version 2>/dev/null || echo "not installed"
+    echo -n "  Node:   "; node --version 2>/dev/null || echo "not installed"
+    echo -n "  npm:    "; npm --version 2>/dev/null || echo "not installed"
+    echo -n "  Go:     "; go version 2>/dev/null || echo "not installed"
+    echo ""
+
+    header "Changed Languages (vs main)"
+    local changed
+    changed=$(detect_changed_languages)
+    if [[ "$changed" == "none" ]]; then
+        info "No language-specific changes detected"
+    else
+        for lang in $changed; do
+            echo -e "  ${GREEN}*${RESET} $lang"
+        done
+    fi
+}
+
+cmd_setup() {
+    header "Checking Development Environment"
+    local missing=0
+
+    info "Required tools:"
+    check_tool rustc     || ((missing++))
+    check_tool cargo     || ((missing++))
+    check_tool protoc    || ((missing++))
+
+    echo ""
+    info "Language-specific tools:"
+    check_tool java      || ((missing++))
+    check_tool python3   || ((missing++))
+    check_tool node      || ((missing++))
+    check_tool npm       || ((missing++))
+    check_tool go        || ((missing++))
+
+    echo ""
+    info "Optional tools:"
+    check_tool cargo-clippy || warn "cargo clippy not available (install via rustup component add clippy)"
+    check_tool cargo-fmt    || warn "cargo fmt not available (install via rustup component add rustfmt)"
+    check_tool valkey-server || {
+        check_tool redis-server || warn "No valkey-server or redis-server found (needed for integration tests)"
+    }
+
+    echo ""
+    if [[ $missing -gt 0 ]]; then
+        err "$missing required tool(s) missing"
+        return 1
+    else
+        ok "All required tools present"
+    fi
+}
+
+cmd_fmt() {
+    local lang="${1:-all}"
+
+    case "$lang" in
+        rust|all-rust)
+            header "Formatting Rust"
+            cargo fmt --all
+            ok "Rust formatted"
+            ;;&
+        java|all-java)
+            header "Formatting Java"
+            cd java && ./gradlew :spotlessApply && cd "$ROOT_DIR"
+            ok "Java formatted"
+            ;;&
+        python|all-python)
+            header "Formatting Python"
+            cd python && python3 dev.py lint && cd "$ROOT_DIR"
+            ok "Python formatted"
+            ;;&
+        node|all-node)
+            header "Formatting Node.js"
+            cd node && npx prettier --write src/ tests/ && cd "$ROOT_DIR"
+            ok "Node.js formatted"
+            ;;&
+        go|all-go)
+            header "Formatting Go"
+            cd go && make format && cd "$ROOT_DIR"
+            ok "Go formatted"
+            ;;&
+        all)
+            # The case fall-through above handles 'all' for each language
+            ;;
+        rust|java|python|node|go)
+            ;; # already handled
+        *)
+            err "Unknown language: $lang (valid: rust, java, python, node, go, all)"
+            return 1
+            ;;
+    esac
+}
+
+cmd_lint() {
+    local lang="${1:-all}"
+    local failed=0
+
+    case "$lang" in
+        rust)
+            header "Linting Rust"
+            cargo clippy --all-targets -- -D warnings || ((failed++))
+            cargo fmt --all -- --check || ((failed++))
+            ;;
+        java)
+            header "Linting Java"
+            cd java && ./gradlew :spotlessCheck && cd "$ROOT_DIR" || ((failed++))
+            ;;
+        python)
+            header "Linting Python"
+            cd python && python3 dev.py lint && cd "$ROOT_DIR" || ((failed++))
+            ;;
+        node)
+            header "Linting Node.js"
+            cd node && npx eslint . && cd "$ROOT_DIR" || ((failed++))
+            ;;
+        go)
+            header "Linting Go"
+            cd go && make lint && cd "$ROOT_DIR" || ((failed++))
+            ;;
+        all)
+            for l in "${LANGUAGES[@]}"; do
+                cmd_lint "$l" || ((failed++))
+            done
+            ;;
+        *)
+            err "Unknown language: $lang (valid: rust, java, python, node, go, all)"
+            return 1
+            ;;
+    esac
+
+    if [[ $failed -gt 0 ]]; then
+        err "$failed linter(s) failed"
+        return 1
+    fi
+    ok "Lint passed"
+}
+
+cmd_build() {
+    local lang="${1:-all}"
+    local failed=0
+
+    case "$lang" in
+        rust)
+            header "Building Rust core"
+            cargo build --release
+            ;;
+        java)
+            header "Building Java"
+            make java || ((failed++))
+            ;;
+        python)
+            header "Building Python"
+            make python || ((failed++))
+            ;;
+        node)
+            header "Building Node.js"
+            make node || ((failed++))
+            ;;
+        go)
+            header "Building Go"
+            make go || ((failed++))
+            ;;
+        all)
+            for l in "${LANGUAGES[@]}"; do
+                cmd_build "$l" || ((failed++))
+            done
+            ;;
+        *)
+            err "Unknown language: $lang (valid: rust, java, python, node, go, all)"
+            return 1
+            ;;
+    esac
+
+    if [[ $failed -gt 0 ]]; then
+        err "$failed build(s) failed"
+        return 1
+    fi
+    ok "Build passed"
+}
+
+cmd_test() {
+    local lang="${1:-all}"
+    local failed=0
+
+    case "$lang" in
+        rust)
+            header "Testing Rust core"
+            cd glide-core && cargo test && cd "$ROOT_DIR" || ((failed++))
+            ;;
+        java)
+            header "Testing Java"
+            make java-test || ((failed++))
+            ;;
+        python)
+            header "Testing Python"
+            make python-test || ((failed++))
+            ;;
+        node)
+            header "Testing Node.js"
+            make node-test || ((failed++))
+            ;;
+        go)
+            header "Testing Go"
+            cd go && make unit-test && cd "$ROOT_DIR" || ((failed++))
+            ;;
+        all)
+            for l in "${LANGUAGES[@]}"; do
+                cmd_test "$l" || ((failed++))
+            done
+            ;;
+        *)
+            err "Unknown language: $lang (valid: rust, java, python, node, go, all)"
+            return 1
+            ;;
+    esac
+
+    if [[ $failed -gt 0 ]]; then
+        err "$failed test suite(s) failed"
+        return 1
+    fi
+    ok "Tests passed"
+}
+
+cmd_check() {
+    header "Pre-push Check"
+    local lang="${1:-}"
+    local targets
+    local failed=0
+
+    if [[ -n "$lang" ]]; then
+        targets=("$lang")
+    else
+        # Auto-detect changed languages
+        local changed
+        changed=$(detect_changed_languages)
+        if [[ "$changed" == "none" ]]; then
+            info "No language changes detected, checking Rust core only"
+            targets=(rust)
+        else
+            IFS=' ' read -ra targets <<< "$changed"
+        fi
+    fi
+
+    info "Checking: ${targets[*]}"
+    echo ""
+
+    for t in "${targets[@]}"; do
+        cmd_lint "$t" || ((failed++))
+    done
+
+    # Always check Rust core builds since all languages depend on it
+    if [[ ! " ${targets[*]} " =~ " rust " ]]; then
+        header "Building Rust core (dependency)"
+        cargo check --release || ((failed++))
+    fi
+
+    for t in "${targets[@]}"; do
+        cmd_build "$t" || ((failed++))
+    done
+
+    echo ""
+    if [[ $failed -gt 0 ]]; then
+        err "Pre-push check failed ($failed failure(s))"
+        return 1
+    fi
+    ok "Pre-push check passed - ready to push"
+}
+
+cmd_changed() {
+    header "Changed Languages (vs main)"
+    local changed
+    changed=$(detect_changed_languages)
+    if [[ "$changed" == "none" ]]; then
+        info "No language-specific changes detected"
+    else
+        for lang in $changed; do
+            echo -e "  ${GREEN}*${RESET} $lang"
+            # Show changed files for this language
+            local pattern
+            case "$lang" in
+                rust)   pattern='^(glide-core/|logger_core/|ffi/|Cargo)' ;;
+                java)   pattern='^java/' ;;
+                python) pattern='^python/' ;;
+                node)   pattern='^node/' ;;
+                go)     pattern='^go/' ;;
+            esac
+            git diff --name-only main...HEAD 2>/dev/null | grep -E "$pattern" | sed 's/^/      /' || true
+        done
+    fi
+}
+
+cmd_help() {
+    echo -e "${BOLD}Valkey GLIDE Developer Toolkit${RESET}"
+    echo ""
+    echo "Usage: ./dev.sh <command> [language]"
+    echo ""
+    echo "Commands:"
+    echo "  status        Show repo and toolchain status"
+    echo "  setup         Verify development environment prerequisites"
+    echo "  check [lang]  Pre-push validation (lint + build for changed languages)"
+    echo "  fmt   [lang]  Format code (default: all)"
+    echo "  lint  [lang]  Lint code (default: all)"
+    echo "  build [lang]  Build (default: all)"
+    echo "  test  [lang]  Run tests (default: all)"
+    echo "  changed       Show which languages have changes vs main"
+    echo "  help          Show this help message"
+    echo ""
+    echo "Languages: rust, java, python, node, go, all"
+    echo ""
+    echo "Examples:"
+    echo "  ./dev.sh status          # Show toolchain versions and changed files"
+    echo "  ./dev.sh check           # Auto-detect changes and validate"
+    echo "  ./dev.sh check rust      # Validate only Rust changes"
+    echo "  ./dev.sh fmt java        # Format Java code"
+    echo "  ./dev.sh lint python     # Lint Python code"
+    echo "  ./dev.sh build node      # Build Node.js client"
+    echo "  ./dev.sh test go         # Run Go unit tests"
+}
+
+# ── Main ─────────────────────────────────────────────────────────────
+
+command="${1:-help}"
+shift || true
+
+case "$command" in
+    status)  cmd_status "$@" ;;
+    setup)   cmd_setup "$@" ;;
+    check)   cmd_check "$@" ;;
+    fmt)     cmd_fmt "$@" ;;
+    lint)    cmd_lint "$@" ;;
+    build)   cmd_build "$@" ;;
+    test)    cmd_test "$@" ;;
+    changed) cmd_changed "$@" ;;
+    help|-h|--help) cmd_help ;;
+    *)
+        err "Unknown command: $command"
+        cmd_help
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

- **`dev.sh`**: Unified developer CLI providing a single entry point for cross-language operations (status, setup, check, fmt, lint, build, test, changed). Auto-detects which languages have changes and runs targeted validation.
- **Makefile enhancements**: Added missing Rust core targets (`rust`, `rust-test`, `rust-lint`, `rust-fmt`) and cross-language targets (`check`, `status`, `fmt-all`, `lint-all`). Improved `help` output with organized categories.
- **CLAUDE.md enhancements**: Added developer toolkit docs, per-language command quick-reference (XML format), workflow recipes (adding commands, core change impact assessment, debugging integration tests), and troubleshooting section for common build failures.
- **AGENTS.md update**: Documents the new `dev.sh` toolkit and all new Makefile targets for agent discoverability.

## Motivation

The repo had per-language build systems but no unified developer experience. Agents and developers had to know language-specific commands for each stack. This toolkit:
1. Reduces onboarding friction with `./dev.sh setup`
2. Enables smart pre-push checks that auto-detect changed languages
3. Provides workflow recipes for common multi-language tasks
4. Makes the Rust core a first-class citizen in the Makefile

## Test plan

- [x] `./dev.sh help` outputs usage correctly
- [x] `./dev.sh status` shows toolchain versions and changed languages
- [x] `./dev.sh setup` validates prerequisites (correctly reports missing tools)
- [x] `make help` shows organized target categories
- [x] `make -n rust` / `make -n check` dry-runs validate Makefile syntax
- [ ] Manual: `./dev.sh check rust` on a machine with full toolchain
- [ ] Manual: `./dev.sh fmt java` formats Java code correctly