### PR TITLE
[pub-agent] docs: enhance CLAUDE.md and AGENTS.md for AI agent effectiveness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,15 @@ This is the Valkey GLIDE mono-repository containing a Rust core (`glide-core`) a
 - `examples/` - Usage examples for each language binding
 - `docs/` - Documentation and MkDocs configuration
 
+**Critical Files (start here for common tasks):**
+- `glide-core/src/request_type.rs` - All 600+ command type mappings (enum + Redis command strings)
+- `glide-core/src/client/mod.rs` - Main Client struct, command routing, lazy init
+- `glide-core/src/client/value_conversion.rs` - Response type coercion logic
+- `glide-core/src/errors.rs` - Error types that propagate to all languages
+- `glide-core/src/protobuf/command_request.proto` - Protobuf command definitions
+- `glide-core/src/socket_listener.rs` - Unix socket IPC for Python async / Node.js
+- `ffi/src/lib.rs` - C FFI for Go / Python sync (CommandResponse struct)
+
 ## Architecture Quick Facts
 
 **Core Implementation:** Rust (`glide-core`) with FFI exposure to language adapters
@@ -202,6 +211,61 @@ valkey-glide/
 └── Makefile            # Top-level build orchestration
 ```
 
+## Adding a New Command (Cross-Language Workflow)
+
+The most common task. Changes flow top-down through these layers:
+
+```
+1. glide-core/src/protobuf/command_request.proto  → Add RequestType enum value (unique ID by category)
+2. glide-core/src/request_type.rs                 → Add #[repr(C)] enum + get_command() match arm
+3. glide-core/src/client/mod.rs                   → Only if special routing/response handling needed
+4. glide-core/src/client/value_conversion.rs       → Only if non-standard response type conversion
+5. Language wrapper (client method + command builder + tests)
+6. Regenerate protobuf for each affected language
+```
+
+**RequestType ID ranges:** bitmap=100s, cluster=200s, connection=300s, generic=400s, hash=500s, hyper=600s, list=700s, pubsub=800s, scripting=900s, server=1000s, set=1100s, sorted-set=1200s, stream=1300s, string=1400s, transaction=1500s
+
+**Protobuf regeneration after .proto changes:**
+- Java: automatic on `./gradlew build`
+- Python: `cd python && python3 dev.py protobuf`
+- Node: `cd node && npm run build-protobuf`
+- Go: `cd go && make generate-protobuf`
+
+## Cross-Language Change Propagation
+
+When modifying `glide-core/` or `ffi/`, changes affect all bindings:
+
+| Change Type | Affects | Action Required |
+|-------------|---------|-----------------|
+| `.proto` schema | All languages | Regenerate protobuf, update all wrappers |
+| `request_type.rs` | All languages | Ensure enum IDs match proto, update FFI |
+| `errors.rs` | All languages | Update error handling in each wrapper |
+| `socket_listener.rs` | Python async, Node.js | Test socket IPC path |
+| `ffi/src/lib.rs` | Go, Python sync, Java | Test FFI/JNI/CGO path |
+| `value_conversion.rs` | All languages | Verify response types in each wrapper |
+
+**Build order (must be respected):**
+1. Rust core (`glide-core/`, `ffi/`)
+2. Protobuf regeneration
+3. Language-specific build
+4. Tests
+
+## Error Flow Architecture
+
+```
+Valkey/Redis server error
+  → redis-rs (forked at glide-core/redis-rs/)
+    → glide-core/src/errors.rs → RequestErrorType {Unspecified, ExecAbort, Timeout, Disconnect}
+      → Socket IPC path (response.proto): error string in protobuf response
+        → Python async: GlideError subclasses
+        → Node.js: Error objects with type + message
+      → FFI path: CommandResponse with error pointer
+        → Java: JNI exception (java/src/errors.rs bridge)
+        → Go: standard error interface
+        → Python sync: CFFI error string
+```
+
 ## Quality Gates (Agent Checklist)
 
 - [ ] Build passes: `make all` succeeds
@@ -209,8 +273,10 @@ valkey-glide/
 - [ ] Tests pass: `make *-test` targets succeed
 - [ ] No generated outputs committed (check `.gitignore`)
 - [ ] DCO signoff present: `git log --format="%B" -n 1 | grep "Signed-off-by"`
+- [ ] Commit cryptographically signed (shows "Verified" on GitHub)
 - [ ] Conventional commit format used
 - [ ] Cross-language API consistency maintained
+- [ ] Protobuf regenerated for all affected languages after .proto changes
 - [ ] Security scan passes (no secrets committed)
 
 ## Quick Facts for Reasoners

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Valkey GLIDE is an official open-source client library for Valkey and Redis OSS. It uses a core driver written in Rust with language-specific wrappers for Python, Java, Node.js, and Go, and other languages in seperate repositories.
+Valkey GLIDE is an official open-source client library for Valkey and Redis OSS. It uses a core driver written in Rust with language-specific wrappers for Python, Java, Node.js, and Go, and other languages in separate repositories.
 
 ## Hard Constraints (non-negotiable)
 - NO task completion without tests covering it and passing
@@ -47,15 +47,74 @@ Valkey GLIDE is an official open-source client library for Valkey and Redis OSS.
 
 ---
 
+## Commit & PR Requirements
+
+All commits **must** include:
+1. **DCO signoff**: `git commit -s -m "feat(scope): message"` (adds `Signed-off-by:` line)
+2. **Cryptographic signature**: `git commit -S -s -m "feat(scope): message"` (shows "Verified" on GitHub)
+3. **Conventional Commits format**: `<type>(<scope>): <description>`
+   - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+   - Scopes: `core`, `java`, `python`, `node`, `go`, `ffi`, `jedis-compatibility`
+   - Example: `feat(java): implement CLUSTER SCAN command`
+
+Missing DCO signoff or signature will fail CI checks.
+
+---
+
+## Build & Test Quick Reference
+
+<build-commands>
+  <language name="rust-core">
+    <build>cd glide-core &amp;&amp; cargo build --release</build>
+    <test>cd glide-core &amp;&amp; cargo test</test>
+    <lint>cd glide-core &amp;&amp; cargo clippy --all-features --all-targets -- -D warnings</lint>
+    <format>cd glide-core &amp;&amp; cargo fmt --all</format>
+  </language>
+  <language name="java">
+    <build>cd java &amp;&amp; ./gradlew :client:buildAllRelease</build>
+    <test>cd java &amp;&amp; ./gradlew :integTest:test</test>
+    <unit-test>cd java &amp;&amp; ./gradlew :client:test</unit-test>
+    <lint>cd java &amp;&amp; ./gradlew :spotlessApply</lint>
+    <check>cd java &amp;&amp; ./gradlew :spotlessCheck</check>
+  </language>
+  <language name="python">
+    <build>cd python &amp;&amp; python3 dev.py build --mode release</build>
+    <test>cd python &amp;&amp; python3 dev.py test</test>
+    <lint>cd python &amp;&amp; python3 dev.py lint</lint>
+    <protobuf>cd python &amp;&amp; python3 dev.py protobuf</protobuf>
+  </language>
+  <language name="node">
+    <build>cd node &amp;&amp; npm install &amp;&amp; npm run build:release</build>
+    <test>cd node &amp;&amp; npm test</test>
+    <lint>cd node &amp;&amp; npm run lint:fix</lint>
+    <protobuf>cd node &amp;&amp; npm run build-protobuf</protobuf>
+  </language>
+  <language name="go">
+    <build>cd go &amp;&amp; make build</build>
+    <test>cd go &amp;&amp; make integ-test</test>
+    <unit-test>cd go &amp;&amp; make unit-test</unit-test>
+    <lint>cd go &amp;&amp; make lint</lint>
+    <format>cd go &amp;&amp; make format</format>
+    <protobuf>cd go &amp;&amp; make generate-protobuf</protobuf>
+  </language>
+  <language name="top-level">
+    <build-all>make all</build-all>
+    <check-server>which valkey-server || which redis-server</check-server>
+    <note>All integration tests require a running Valkey/Redis server. Use utils/cluster_manager.py to start one.</note>
+  </language>
+</build-commands>
+
+---
+
 ## Project Structure
 
 ```
 glide-core/     # Rust core driver - handles connection, protocol, clustering
-python/         # Python client wrapper
-java/           # Java client wrapper
-node/           # Node.js client wrapper
-go/             # Go client wrapper
-ffi/            # Foreign function interface for language bindings
+python/         # Python client wrapper (async via PyO3, sync via CFFI)
+java/           # Java client wrapper (JNI) + Jedis compatibility layer
+node/           # Node.js client wrapper (NAPI v2)
+go/             # Go client wrapper (CGO/FFI)
+ffi/            # Foreign function interface for Go and Python sync
 logger_core/    # Rust logging infrastructure
 utils/          # Test utilities and cluster management scripts
 benchmarks/     # Performance benchmarks
@@ -76,6 +135,120 @@ docs/           # Documentation
 Socket IPC wrappers → `socket_listener` → `glide-core` → Valkey/Redis
 FFI wrappers → `glide-core` → Valkey/Redis
 
+---
+
+## Adding a New Command (Cookbook)
+
+This is the most common task. Follow these steps in order:
+
+### Step 1: Protobuf Definition
+**File:** `glide-core/src/protobuf/command_request.proto`
+- Add enum variant to `RequestType` with a unique numeric ID
+- IDs are grouped by category in 100s: bitmap=100s, cluster=200s, connection=300s, generic=400s, hash=500s, hyper=600s, list=700s, pubsub=800s, scripting=900s, server=1000s, set=1100s, sorted-set=1200s, stream=1300s, string=1400s, transaction=1500s
+
+### Step 2: Rust RequestType Enum
+**File:** `glide-core/src/request_type.rs`
+- Add matching `#[repr(C)]` enum variant with same numeric ID
+- Add `get_command()` match arm mapping to the actual Redis/Valkey command string
+
+### Step 3: Core Client Logic (if needed)
+**File:** `glide-core/src/client/mod.rs`
+- Most commands use the default dispatch path and need no changes here
+- Only add handling if the command needs special routing, multi-slot logic, or response transformation
+
+### Step 4: Response Conversion (if needed)
+**File:** `glide-core/src/client/value_conversion.rs`
+- Add conversion logic if the command returns a non-standard type that needs coercion
+
+### Step 5: Language Wrapper Implementation
+Implement in the target language wrapper. Each language follows the same pattern: define the method on the client class, construct the protobuf request, and return the typed response.
+
+<command-impl-files>
+  <language name="java">
+    <interface>java/client/src/main/java/glide/api/commands/ (add to relevant *BaseCommands interface)</interface>
+    <client>java/client/src/main/java/glide/api/BaseClient.java (implement method)</client>
+    <standalone>java/client/src/main/java/glide/api/GlideClient.java (standalone-only methods)</standalone>
+    <cluster>java/client/src/main/java/glide/api/GlideClusterClient.java (cluster-only methods)</cluster>
+    <batch>java/client/src/main/java/glide/api/models/BaseBatch.java (add batch support)</batch>
+    <unit-test>java/client/src/test/java/glide/ (GlideClientTest / GlideClusterClientTest)</unit-test>
+    <integ-test>java/integTest/src/test/java/glide/ (add to relevant test suite)</integ-test>
+  </language>
+  <language name="python">
+    <commands>python/glide-shared/glide_shared/commands/ (add to relevant mixin)</commands>
+    <async-client>python/glide-async/python/glide/glide_client.py</async-client>
+    <sync-commands>python/glide-sync/glide_sync/sync_commands/ (sync version)</sync-commands>
+    <tests>python/tests/ (add to relevant test file)</tests>
+  </language>
+  <language name="node">
+    <commands>node/src/Commands.ts (add command builder function)</commands>
+    <client>node/src/BaseClient.ts (add client method)</client>
+    <tests>node/tests/ (add to relevant test file)</tests>
+  </language>
+  <language name="go">
+    <client>go/base_client.go (implement method on baseClient)</client>
+    <standalone>go/glide_client.go (standalone-only methods)</standalone>
+    <cluster>go/glide_cluster_client.go (cluster-only methods)</cluster>
+    <tests>go/integTest/ (add to relevant test suite)</tests>
+  </language>
+</command-impl-files>
+
+### Step 6: Regenerate Protobuf
+After changing `.proto` files, regenerate for each language you're touching:
+- **Java**: Gradle picks up changes automatically on build
+- **Python**: `cd python && python3 dev.py protobuf`
+- **Node**: `cd node && npm run build-protobuf`
+- **Go**: `cd go && make generate-protobuf`
+
+### Step 7: Tests
+- Add unit tests for argument construction
+- Add integration tests that exercise the command against a live server
+- Test both standalone and cluster clients
+- Include edge cases: empty args, wrong types, server version gating
+
+---
+
+## Cross-Language Change Checklist
+
+When modifying `glide-core/` or `ffi/`, changes propagate to all languages. Use this checklist:
+
+- [ ] Protobuf schema changes regenerated for all affected languages
+- [ ] `request_type.rs` enum and `get_command()` match arm both updated
+- [ ] Socket IPC path tested (Python async, Node.js)
+- [ ] FFI path tested (Python sync, Go, Java)
+- [ ] Error type changes reflected in all language wrappers
+- [ ] Build order respected: Rust core → protobuf regen → language build → tests
+
+---
+
+## Error Flow
+
+```
+Valkey/Redis → redis-rs → RedisError
+  → glide-core/src/errors.rs (RequestErrorType: Unspecified|ExecAbort|Timeout|Disconnect)
+    → Socket IPC: error string via protobuf response.proto
+      → Python async: GlideError subclasses
+      → Node.js: Error objects with type/message
+    → FFI: CommandResponse with error pointer
+      → Java: JNI exception bridge (java/src/errors.rs)
+      → Go: standard error interface
+      → Python sync: CFFI error string
+```
+
+---
+
+## Key Constants & Defaults
+
+| Constant | Value | File |
+|----------|-------|------|
+| Response timeout | 250ms | `glide-core/src/client/mod.rs` |
+| Connection timeout | 2000ms | `glide-core/src/client/mod.rs` |
+| Max retries | 3 | `glide-core/src/client/mod.rs` |
+| Max inflight requests | 1000 | `glide-core/src/client/mod.rs` |
+| Heartbeat interval | 1s | `glide-core/src/client/mod.rs` |
+| Connection check interval | 3s | `glide-core/src/client/mod.rs` |
+
+---
+
 ## Context Retrieval
 
 <context-sources>
@@ -88,6 +261,7 @@ FFI wrappers → `glide-core` → Valkey/Redis
     <client>python/glide-async/python/glide/glide_client.py</client>
     <commands>python/glide-shared/glide_shared/commands/</commands>
     <tests>python/tests/</tests>
+    <dev-cli>python/dev.py</dev-cli>
   </language>
   <language name="python-sync">
     <triggers>python sync, CFFI, glide-sync, synchronous python</triggers>
@@ -98,6 +272,7 @@ FFI wrappers → `glide-core` → Valkey/Redis
     <client>python/glide-sync/glide_sync/glide_client.py</client>
     <commands>python/glide-sync/glide_sync/sync_commands/</commands>
     <tests>python/tests/</tests>
+    <dev-cli>python/dev.py</dev-cli>
   </language>
   <language name="java">
     <triggers>java, JNI, glide-rs, Java client</triggers>
@@ -105,9 +280,13 @@ FFI wrappers → `glide-core` → Valkey/Redis
     <depends-on>core</depends-on>
     <entry>java/Cargo.toml</entry>
     <bindings>java/src/lib.rs</bindings>
-    <client>java/client/src/main/java/glide/api/</client>
+    <client>java/client/src/main/java/glide/api/BaseClient.java</client>
     <commands>java/client/src/main/java/glide/api/commands/</commands>
+    <batch>java/client/src/main/java/glide/api/models/BaseBatch.java</batch>
+    <errors>java/src/errors.rs</errors>
     <tests>java/client/src/test/java/glide/</tests>
+    <integ-tests>java/integTest/src/test/java/glide/</integ-tests>
+    <jedis-compat>java/jedis-compatibility/</jedis-compat>
   </language>
   <language name="node">
     <triggers>node, nodejs, NAPI, typescript, rust-client node</triggers>
@@ -126,7 +305,8 @@ FFI wrappers → `glide-core` → Valkey/Redis
     <entry>go/Makefile</entry>
     <bindings>go/callbacks.go</bindings>
     <client>go/base_client.go</client>
-    <commands>go/internal/interfaces/</commands>
+    <standalone>go/glide_client.go</standalone>
+    <cluster>go/glide_cluster_client.go</cluster>
     <tests>go/integTest/</tests>
   </language>
   <language name="core">
@@ -134,8 +314,14 @@ FFI wrappers → `glide-core` → Valkey/Redis
     <start-with>glide-core/src/client/mod.rs</start-with>
     <entry>glide-core/Cargo.toml</entry>
     <client>glide-core/src/client/mod.rs</client>
+    <request-types>glide-core/src/request_type.rs</request-types>
+    <value-conversion>glide-core/src/client/value_conversion.rs</value-conversion>
+    <errors>glide-core/src/errors.rs</errors>
     <socket>glide-core/src/socket_listener.rs</socket>
     <protobuf>glide-core/src/protobuf/</protobuf>
+    <reconnection>glide-core/src/client/reconnecting_connection.rs</reconnection>
+    <standalone>glide-core/src/client/standalone_client.rs</standalone>
+    <compression>glide-core/src/compression.rs</compression>
     <tests>glide-core/tests/</tests>
   </language>
   <language name="ffi">
@@ -145,3 +331,13 @@ FFI wrappers → `glide-core` → Valkey/Redis
     <bindings>ffi/src/lib.rs</bindings>
   </language>
 </context-sources>
+
+## Common Pitfalls
+
+- Forgetting `--features "proto,socket-layer"` when building glide-core standalone (socket listener won't compile)
+- Running integration tests without a Valkey/Redis server running (tests hang or timeout)
+- Not regenerating protobuf after `.proto` changes (build succeeds but new commands are missing)
+- Editing Java commands without checking the Jedis compatibility interfaces need updating too
+- Forgetting license headers in new Go files: `// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0`
+- Missing DCO signoff on commits (CI will reject the PR)
+- Not respecting build order: Rust core must build before language wrappers


### PR DESCRIPTION
## Summary

Significantly improves agent effectiveness when working on this repository by adding critical operational knowledge to CLAUDE.md and AGENTS.md.

### CLAUDE.md improvements:
- **Command Addition Cookbook** - Step-by-step guide through all 7 layers (protobuf -> request_type -> core -> value_conversion -> language wrapper -> protobuf regen -> tests). This is the #1 most common task.
- **Build & Test Quick Reference** - XML-structured inline commands for all 5 languages + top-level Make targets. Agents no longer need to search through 6 different AGENTS.md files.
- **Commit & PR Requirements** - DCO signoff + cryptographic signing + conventional commits format. Missing these fails CI, and the old CLAUDE.md didn't mention them.
- **Cross-Language Change Checklist** - What to verify when modifying glide-core/ or ffi/
- **Error Flow Architecture** - How errors propagate from Valkey through redis-rs to glide-core to Socket IPC/FFI to each language
- **Key Constants & Defaults** - Response timeout, connection timeout, max retries, etc.
- **Expanded Context Sources** - Added critical files (request_type.rs, value_conversion.rs, errors.rs, reconnecting_connection.rs, compression.rs) and corrected paths (Go commands live on base_client.go, not in a separate directory)
- **Common Pitfalls** - The 7 most frequent mistakes agents make

### AGENTS.md improvements:
- **Cross-language command addition workflow** with ID range reference
- **Change propagation matrix** - Which changes affect which bindings
- **Error flow architecture** diagram
- **Critical files quick reference** for the most common tasks
- **Extended quality gates** checklist (protobuf regen, commit signing)

## Test plan
- [x] All file paths verified against actual repository structure
- [x] Build commands verified against Makefile and language-specific configs
- [x] RequestType ID ranges verified against command_request.proto
- [x] Go command structure verified (methods on base_client.go, not separate directory)
- [x] Java paths verified (BaseClient.java, commands/, BaseBatch.java all exist)