### PR TITLE
[pub-agent] docs: enhance agent context with command workflow, error refs, and debugging guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS: Unified Context for Agentic Tools
 
-This file provides AI agents with the minimum but sufficient context to work productively in the Valkey GLIDE mono-repository. It covers build commands, contribution requirements, and essential guardrails for maintaining code quality across multiple language bindings.
+This file provides AI agents with the minimum but sufficient context to work productively in the Valkey GLIDE mono-repository. It covers build commands, contribution requirements, command implementation patterns, and essential guardrails for maintaining code quality across multiple language bindings.
 
 ## Repository Overview
 
@@ -11,10 +11,10 @@ This is the Valkey GLIDE mono-repository containing a Rust core (`glide-core`) a
 **Key Components:**
 - `glide-core/` - Core Rust implementation with async client logic
 - `ffi/` - Foreign Function Interface layer for language interoperability
-- `java/` - Java client bindings with Gradle build system
-- `python/` - Python async/sync client bindings
-- `node/` - Node.js/TypeScript client bindings with npm
-- `go/` - Go client bindings
+- `java/` - Java client bindings with Gradle build system + Jedis compatibility layer
+- `python/` - Python async (PyO3) and sync (CFFI) client bindings
+- `node/` - Node.js/TypeScript client bindings with NAPI v2
+- `go/` - Go client bindings via CGO/FFI
 - `logger_core/` - Shared logging infrastructure
 - `utils/` - Shared utilities and cluster management tools
 - `benchmarks/` - Performance benchmarks across languages
@@ -23,9 +23,12 @@ This is the Valkey GLIDE mono-repository containing a Rust core (`glide-core`) a
 
 ## Architecture Quick Facts
 
-**Core Implementation:** Rust (`glide-core`) with FFI exposure to language adapters
+**Core Implementation:** Rust (`glide-core`) with two IPC paths to language adapters:
+- **Socket IPC** (Python async, Node.js): Protobuf messages over Unix domain socket
+- **FFI** (Java JNI, Go CGO, Python sync CFFI): Direct C function calls with `CommandResponse` struct
+
 **Design Constraints:** Async-first APIs, cluster-aware routing, batching support, cross-AZ affinity
-**Key Features:** Multi-slot command handling, PubSub auto-reconnection, cluster scan, OpenTelemetry integration
+**Key Features:** Multi-slot command handling, PubSub auto-reconnection, cluster scan, OpenTelemetry integration, transparent compression (Zstd/LZ4), IAM authentication
 
 **Supported Engine Versions:**
 | Engine Type | 6.2 | 7.0 | 7.1 | 7.2 | 8.0 | 8.1 |
@@ -46,7 +49,7 @@ make python        # Build Python async + sync clients (release mode)
 make node          # Build Node.js client (release mode)
 make go            # Build Go client
 
-# Testing
+# Testing (requires running Valkey/Redis server)
 make java-test     # Run Java integration tests
 make python-test   # Run Python tests
 make node-test     # Run Node.js tests
@@ -57,6 +60,10 @@ make java-lint     # Run Java spotlessApply
 make python-lint   # Run Python linters via dev.py
 make node-lint     # Run Node.js linters
 make go-lint       # Run Go linters
+
+# Formatting
+make prettier-check  # Check Prettier formatting
+make prettier-fix    # Fix Prettier formatting
 
 # Utilities
 make clean         # Remove .build/ directory
@@ -78,9 +85,12 @@ cargo fmt
 **Java:**
 ```bash
 cd java
-./gradlew :client:buildAllRelease
-./gradlew :integTest:test
-./gradlew :spotlessApply
+./gradlew :client:buildAllRelease       # Build
+./gradlew :client:test                   # Unit tests
+./gradlew :integTest:test                # Integration tests
+./gradlew :integTest:pubsubTest          # PubSub tests
+./gradlew :integTest:test --tests 'methodName' --rerun  # Single test
+./gradlew :spotlessApply                 # Lint/format
 ```
 
 **Python:**
@@ -97,7 +107,7 @@ cd node
 npm install
 npm run build:release
 npm test
-npx run lint:fix
+npx eslint --fix .
 ```
 
 **Go:**
@@ -106,8 +116,6 @@ cd go
 make build
 make test
 make lint
-go build ./...
-go test ./...
 ```
 
 **Benchmarks:**
@@ -119,7 +127,21 @@ cd glide-core && cargo bench
 cd benchmarks && ./install_and_test.sh
 ```
 
-**Test Results:** Stored in language-specific directories (`target/`, `build/`, `node_modules/`, etc.)
+## Command Implementation Pattern
+
+The most common development task is adding new Valkey/Redis commands. The flow:
+
+1. **Protobuf** (`glide-core/src/protobuf/command_request.proto`): Add `RequestType` enum variant
+2. **Rust core** (`glide-core/src/request_type.rs`): Add enum variant + `get_command()` mapping
+3. **Language bindings**: Add interface method + implementation + tests in each language:
+   - **Java**: Interface in `java/client/src/main/java/glide/api/commands/`, impl in `BaseClient.java`
+   - **Python**: Method in `python/glide-async/python/glide/async_commands/core.py`
+   - **Node.js**: Factory in `node/src/Commands.ts`, method in `node/src/BaseClient.ts`
+   - **Go**: Interface in `go/internal/interfaces/`, impl in `go/base_client.go`
+4. **Jedis compatibility** (if applicable): `java/jedis-compatibility/src/main/java/redis/clients/jedis/Jedis.java`
+5. **Tests**: Unit + integration tests in each language, covering standalone + cluster modes
+
+**Key rule:** Core/protobuf changes affect ALL language bindings. Single-language changes need only that language's tests.
 
 ## Contribution Requirements
 
@@ -131,32 +153,28 @@ All commits must include a `Signed-off-by` line:
 # Add signoff to new commits
 git commit -s -m "feat: add new feature"
 
-# Configure automatic signoff
-git config --global format.signOff true
-
 # Add signoff to existing commit
 git commit --amend --signoff --no-edit
-
-# Add signoff to multiple commits
-git rebase -i HEAD~n --signoff
 ```
 
 **Required format:** `Signed-off-by: Your Name <your.email@example.com>`
 
-### Conventional Commits
+### Commit Signing REQUIRED
 
-Use conventional commit format for all commit messages:
+All commits must be cryptographically signed (GPG or SSH) to show as "Verified" on GitHub:
+
+```bash
+git commit -S -s -m "feat(java): add new command"
+```
+
+### Conventional Commits
 
 ```
 <type>(<scope>): <description>
-
-[optional body]
-
-[optional footer(s)]
 ```
 
-**Common types:** `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
-
+**Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+**Scopes:** `java`, `python`, `node`, `go`, `core`, `ffi`
 **Example:** `feat(java): add cluster scan support for Java client`
 
 ## Guardrails & Policies
@@ -170,11 +188,11 @@ Use conventional commit format for all commit messages:
 - `benchmarks/results/` - Benchmark output
 - `python/.env*` - Python virtual environments
 - `*.class` - Java compiled files
-- Language-specific build directories per `.gitignore`
 
 ### Cross-Language Changes
 - Follow semantic versioning for breaking changes
 - Test changes across affected language bindings
+- Verify API consistency: same command name, same parameter order, same return type semantics
 
 ### Security & Code Quality
 - Never commit secrets, credentials, or API keys
@@ -183,40 +201,55 @@ Use conventional commit format for all commit messages:
 - Maintain compatibility with supported engine versions
 - Do not modify vendored or third-party code
 
-## Project Structure (Essential)
+## Error Handling
 
-```
-valkey-glide/
-├── glide-core/          # Core Rust implementation
-├── ffi/                 # Foreign Function Interface layer
-├── java/                # Java client bindings (Gradle)
-├── python/              # Python async/sync bindings
-├── node/                # Node.js/TypeScript bindings (npm)
-├── go/                  # Go client bindings
-├── logger_core/         # Shared logging infrastructure
-├── utils/               # Cluster management and utilities
-├── benchmarks/          # Performance benchmarks
-├── examples/            # Usage examples per language
-├── docs/                # Documentation (MkDocs)
-├── .github/workflows/   # CI/CD pipelines
-└── Makefile            # Top-level build orchestration
-```
+All language bindings share a consistent error hierarchy:
+
+| Error Type | When | Retryable? |
+|---|---|---|
+| `ClosingError` | Client closed, no longer usable | No |
+| `RequestError` | General command execution failure | Depends |
+| `TimeoutError` | Request exceeded timeout | Yes |
+| `ExecAbortError` | Transaction was aborted | Depends |
+| `ConnectionError` | Connection lost (auto-reconnect may recover) | Yes |
+| `ConfigurationError` | Invalid client configuration | No |
+
+Error files per language:
+- **Rust**: `glide-core/src/errors.rs`
+- **Proto**: `glide-core/src/protobuf/response.proto`
+- **Java**: `java/client/src/main/java/glide/api/models/exceptions/`
+- **Python**: `python/glide-shared/glide_shared/exceptions.py`
+- **Node.js**: `node/src/Errors.ts`
+- **Go**: `go/errors.go`
+
+## Debugging Quick Reference
+
+| Symptom | Likely Cause | Where to Look |
+|---|---|---|
+| PubSub messages not received | Subscription drift after topology change | `glide-core/src/pubsub/synchronizer.rs`, check `subscription_out_of_sync_count` metric |
+| Connection hangs | Inflight limit (1000) reached or topology refresh race | `glide-core/src/client/reconnecting_connection.rs` |
+| Java large response corruption | 16KB JNI Lambda limit | `java/src/lib.rs` — uses direct-buffer path for large arrays |
+| Empty hostname in cluster | AWS ElastiCache returning `hostname: ""` | Falls back to IP address automatically |
+| Memory leak in async subsystem | Reference cycle in callbacks | Use `Weak` refs in PubSub synchronizer and IAM token manager |
+| Flaky tests | Using `sleep()` instead of polling | Replace with polling + retry + timeout, add `finally`/`defer` cleanup |
 
 ## Quality Gates (Agent Checklist)
 
-- [ ] Build passes: `make all` succeeds
+- [ ] Build passes for changed languages
 - [ ] Lint passes: `make *-lint` targets succeed
-- [ ] Tests pass: `make *-test` targets succeed
+- [ ] Tests pass: unit + integration for changed scope
 - [ ] No generated outputs committed (check `.gitignore`)
 - [ ] DCO signoff present: `git log --format="%B" -n 1 | grep "Signed-off-by"`
+- [ ] Commit is cryptographically signed
 - [ ] Conventional commit format used
-- [ ] Cross-language API consistency maintained
-- [ ] Security scan passes (no secrets committed)
+- [ ] Cross-language API consistency maintained (if core change)
+- [ ] Both standalone and cluster modes tested (if adding command)
+- [ ] Batch/Transaction support added (if command is pipelineable)
 
 ## Quick Facts for Reasoners
 
-**Engines Supported:** Valkey 7.2, 8.0, 8.1, 9.0+ | Redis 6.2, 7.0, 7.1, 7.2
-**Key Features:** AZ Affinity, PubSub auto-reconnection, sharded PubSub, cluster-aware multi-key commands, cluster scan, batching (pipeline/transaction), OpenTelemetry integration
+**Engines Supported:** Valkey 7.2, 8.0, 8.1 | Redis 6.2, 7.0, 7.1, 7.2
+**Key Features:** AZ Affinity, PubSub auto-reconnection, sharded PubSub, cluster-aware multi-key commands, cluster scan, batching (pipeline/transaction), OpenTelemetry, compression (Zstd/LZ4), IAM auth
 **Architecture:** Rust core with FFI bindings, async-first design, cluster and standalone support
 **Performance:** Optimized for high throughput and low latency with connection pooling
 
@@ -224,6 +257,8 @@ valkey-glide/
 
 - **Getting Started:** [README.md](./README.md)
 - **Contributing:** [CONTRIBUTING.md](./CONTRIBUTING.md)
+- **Submitting PRs:** [SUBMITTING_PRS.md](./SUBMITTING_PRS.md)
+- **Reviewing PRs:** [REVIEWING_PRS.md](./REVIEWING_PRS.md)
 - **Security:** [SECURITY.md](./SECURITY.md)
 - **Documentation:** [docs/README.md](./docs/README.md)
 - **Examples:** [examples/](./examples/)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,4 +333,4 @@ Three proto files define the client-core communication:
 | `connection_request.proto` | Client configuration | `ConnectionRequest`, `ReadFrom`, `TlsMode`, `CompressionConfig`, `IamCredentials` |
 | `response.proto` | Response handling | `Response`, `RequestError`, `RequestErrorType`, `ConstantResponse` |
 
-**RequestType ID ranges:** Bitmap=1xx, Cluster=2xx, Connection=3xx, String=4xx, Generic=5xx, Set=6xx, Hash=7xx, List=8xx, SortedSet=9xx, Stream=10xx, HyperLogLog=11xx, Geo=12xx, Scripting=13xx, Server=14xx, PubSub=15xx.
+**RequestType ID ranges:** Bitmap=1xx, Cluster=2xx, Connection=3xx, Generic=4xx, Geospatial=5xx, Hash=6xx, HyperLogLog=7xx, List=8xx, PubSub=9xx, Scripting=10xx, Server=11xx, Set=12xx, SortedSet=13xx, Stream=14xx, String=15xx, Transaction=16xx, JSON=20xx, VectorSearch=21xx.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Valkey GLIDE is an official open-source client library for Valkey and Redis OSS. It uses a core driver written in Rust with language-specific wrappers for Python, Java, Node.js, and Go, and other languages in seperate repositories.
+Valkey GLIDE is an official open-source client library for Valkey and Redis OSS. It uses a core driver written in Rust with language-specific wrappers for Python, Java, Node.js, and Go, and other languages in separate repositories.
 
 ## Hard Constraints (non-negotiable)
 - NO task completion without tests covering it and passing
@@ -51,16 +51,16 @@ Valkey GLIDE is an official open-source client library for Valkey and Redis OSS.
 
 ```
 glide-core/     # Rust core driver - handles connection, protocol, clustering
-python/         # Python client wrapper
-java/           # Java client wrapper
-node/           # Node.js client wrapper
-go/             # Go client wrapper
-ffi/            # Foreign function interface for language bindings
+python/         # Python client wrapper (async via PyO3, sync via CFFI)
+java/           # Java client wrapper (JNI) + Jedis compatibility layer
+node/           # Node.js client wrapper (NAPI v2)
+go/             # Go client wrapper (CGO/FFI)
+ffi/            # Foreign function interface for Go and Python sync
 logger_core/    # Rust logging infrastructure
 utils/          # Test utilities and cluster management scripts
 benchmarks/     # Performance benchmarks
 examples/       # Usage examples for each language
-docs/           # Documentation
+docs/           # Documentation (MkDocs)
 ```
 
 ## Architecture: Language Bindings to Core
@@ -73,8 +73,169 @@ docs/           # Documentation
 | Go           | CGO       | glide-ffi (ffi/)            | FFI calls          |
 | Node.js      | NAPI v2   | rust-client (node/rust-client/)  | Unix socket IPC    |
 
-Socket IPC wrappers → `socket_listener` → `glide-core` → Valkey/Redis
-FFI wrappers → `glide-core` → Valkey/Redis
+```
+Socket IPC path:  Language wrapper → protobuf → socket_listener → glide-core → Valkey/Redis
+FFI path:         Language wrapper → C FFI call → glide-core → Valkey/Redis
+```
+
+## New Command Implementation Workflow
+
+When adding a new Valkey/Redis command, touch these files in order:
+
+<command-workflow>
+  <step order="1" name="Protobuf definition">
+    <file>glide-core/src/protobuf/command_request.proto</file>
+    <action>Add RequestType enum variant with next available ID in the correct category group (Bitmap=1xx, Cluster=2xx, Connection=3xx, String=4xx, Generic=5xx, Set=6xx, Hash=7xx, List=8xx, SortedSet=9xx, Stream=10xx, etc.)</action>
+  </step>
+  <step order="2" name="Rust request type">
+    <file>glide-core/src/request_type.rs</file>
+    <action>Add enum variant, implement get_command() to return the Redis command (Cmd), and map from protobuf type</action>
+  </step>
+  <step order="3" name="Language bindings" note="for each target language">
+    <java>
+      <interface>java/client/src/main/java/glide/api/commands/{Category}BaseCommands.java</interface>
+      <impl>java/client/src/main/java/glide/api/BaseClient.java</impl>
+      <unit-test>java/client/src/test/java/glide/api/GlideClientTest.java</unit-test>
+      <integ-test>java/integTest/src/test/java/glide/SharedCommandTests.java</integ-test>
+      <note>Add Javadoc with @see link to valkey.io docs, @apiNote for cluster behavior</note>
+    </java>
+    <python>
+      <async-commands>python/glide-async/python/glide/async_commands/core.py (or standalone_commands.py / cluster_commands.py)</async-commands>
+      <shared-options>python/glide-shared/glide_shared/commands/ (for option types)</shared-options>
+      <sync-commands>python/glide-sync/glide_sync/sync_commands/ (if sync client needed)</sync-commands>
+      <integ-test>python/tests/</integ-test>
+      <note>Commands use self._execute_command(RequestType.XXX, args). Add docstrings with examples.</note>
+    </python>
+    <node>
+      <factory>node/src/Commands.ts (add createXxx() factory function)</factory>
+      <client>node/src/BaseClient.ts (add method calling the factory)</client>
+      <integ-test>node/tests/</integ-test>
+      <note>Large args (>4KB) use createLeakedStringVec() for pointer passing</note>
+    </node>
+    <go>
+      <interface>go/internal/interfaces/{category}_commands.go</interface>
+      <impl>go/base_client.go</impl>
+      <integ-test>go/integTest/shared_commands_test.go</integ-test>
+      <note>Go uses FFI via C bindings in go/callbacks.go</note>
+    </go>
+  </step>
+  <step order="4" name="Jedis compatibility (if applicable)">
+    <file>java/jedis-compatibility/src/main/java/redis/clients/jedis/Jedis.java</file>
+    <note>Only if the command exists in the Jedis API surface</note>
+  </step>
+  <step order="5" name="Batch/Transaction support">
+    <action>Add command to batch/transaction classes in each language if the command supports pipelining</action>
+  </step>
+</command-workflow>
+
+## Error Hierarchy (consistent across all languages)
+
+```
+GlideError / ValkeyError (base)
+├── ClosingError          — client closed, no longer usable
+└── RequestError          — error during command execution
+    ├── TimeoutError      — request timed out
+    ├── ExecAbortError    — transaction aborted
+    ├── ConnectionError   — connection lost (may auto-reconnect)
+    └── ConfigurationError — invalid configuration
+```
+
+<error-files>
+  <rust>glide-core/src/errors.rs</rust>
+  <protobuf>glide-core/src/protobuf/response.proto (RequestErrorType enum)</protobuf>
+  <java>java/client/src/main/java/glide/api/models/exceptions/</java>
+  <python>python/glide-shared/glide_shared/exceptions.py</python>
+  <node>node/src/Errors.ts</node>
+  <go>go/errors.go</go>
+</error-files>
+
+## Testing Quick Reference
+
+<testing>
+  <language name="java">
+    <unit>cd java && ./gradlew :client:test</unit>
+    <integration>cd java && ./gradlew :integTest:test</integration>
+    <single>cd java && ./gradlew :integTest:test --tests 'testMethodName' --rerun</single>
+    <pubsub>cd java && ./gradlew :integTest:pubsubTest</pubsub>
+    <lint>cd java && ./gradlew :spotlessApply</lint>
+    <prereq>Requires running Valkey/Redis server (check with: which valkey-server || which redis-server)</prereq>
+  </language>
+  <language name="python">
+    <build>cd python && python3 dev.py build --mode release</build>
+    <test>cd python && python3 dev.py test</test>
+    <lint>cd python && python3 dev.py lint</lint>
+  </language>
+  <language name="node">
+    <build>cd node && npm install && npm run build:release</build>
+    <test>cd node && npm test</test>
+    <lint>cd node && npx eslint --fix .</lint>
+  </language>
+  <language name="go">
+    <build>cd go && make build</build>
+    <test>cd go && make test</test>
+    <lint>cd go && make lint</lint>
+  </language>
+  <language name="rust-core">
+    <build>cd glide-core && cargo build --release</build>
+    <test>cd glide-core && cargo test</test>
+    <lint>cd glide-core && cargo clippy && cargo fmt --check</lint>
+    <bench>cd glide-core && cargo bench</bench>
+  </language>
+  <language name="make-targets">
+    <all>make all</all>
+    <note>Use make targets for CI-equivalent builds: make java, make python, make node, make go</note>
+  </language>
+</testing>
+
+## Key Subsystems
+
+<subsystems>
+  <subsystem name="PubSub Synchronizer">
+    <file>glide-core/src/pubsub/synchronizer.rs</file>
+    <desc>Observer pattern with eventual consistency. Reconciles desired vs actual subscriptions every 3s. Handles topology changes, slot migrations, lazy/blocking subscribe modes. Uses Weak refs to avoid reference cycles.</desc>
+  </subsystem>
+  <subsystem name="Compression">
+    <file>glide-core/src/compression.rs</file>
+    <desc>Transparent Zstd/LZ4 compression with 5-byte header (magic + version + backend ID). Minimum 64 bytes threshold. Supported in all language bindings.</desc>
+  </subsystem>
+  <subsystem name="IAM Auth">
+    <file>glide-core/src/iam/</file>
+    <desc>AWS SigV4 token generation for ElastiCache/MemoryDB. Auto-refresh with exponential backoff. Uses Weak refs to avoid reference cycles.</desc>
+  </subsystem>
+  <subsystem name="Socket Listener">
+    <file>glide-core/src/socket_listener.rs</file>
+    <desc>Unix domain socket IPC for Python async and Node.js. Protobuf message framing with rotating buffer.</desc>
+  </subsystem>
+  <subsystem name="Reconnection">
+    <file>glide-core/src/client/reconnecting_connection.rs</file>
+    <desc>Auto-reconnect with configurable exponential backoff. Inflight request limit: 1000 default.</desc>
+  </subsystem>
+  <subsystem name="Cluster Scan">
+    <file>glide-core/src/cluster_scan_container.rs</file>
+    <desc>Cursor management for distributed SCAN across cluster nodes.</desc>
+  </subsystem>
+  <subsystem name="Jedis Compatibility">
+    <dir>java/jedis-compatibility/</dir>
+    <desc>Drop-in Jedis API replacement wrapping GLIDE. Covers UnifiedJedis, Jedis, JedisPooled, JedisCluster. Maven: io.valkey:valkey-glide-jedis-compatibility.</desc>
+  </subsystem>
+  <subsystem name="OpenTelemetry">
+    <dir>glide-core/telemetry/</dir>
+    <desc>Metrics for timeouts, retries, MOVED errors, PubSub sync events. Supports gRPC/HTTP/file export. Span propagation via root_span_ptr in protobuf.</desc>
+  </subsystem>
+</subsystems>
+
+## Common Pitfalls
+
+<pitfalls>
+  <pitfall name="Cross-language consistency">When adding a command to one language, check if it should be added to all others. Core (Rust/protobuf) changes always affect all bindings.</pitfall>
+  <pitfall name="Flaky tests">Never use raw sleep() in tests. Use polling + retry with timeout. Always clean up resources in finally/defer blocks.</pitfall>
+  <pitfall name="DCO signoff">All commits require DCO signoff: `git commit -s`. Missing signoff = CI failure. To fix: `git commit --amend --signoff --no-edit`.</pitfall>
+  <pitfall name="Commit signing">All commits must be cryptographically signed (GPG or SSH) to show as "Verified" on GitHub.</pitfall>
+  <pitfall name="Batch/Transaction">Commands in batch/transaction contexts may have different return types than standalone execution. Test both paths.</pitfall>
+  <pitfall name="Cluster vs Standalone">Some commands behave differently in cluster mode (multi-slot, routing). Always test both modes. Use @apiNote in Java / docstring notes in Python to document cluster-specific behavior.</pitfall>
+  <pitfall name="Large payloads">Node.js: args >4KB need createLeakedStringVec(). Java: JNI has 16KB Lambda limit for inline responses — large arrays use direct-buffer path.</pitfall>
+  <pitfall name="Reference cycles">Async subsystems (PubSub synchronizer, IAM token manager) must use Weak refs in callbacks to avoid preventing client drop/cleanup.</pitfall>
+</pitfalls>
 
 ## Context Retrieval
 
@@ -86,7 +247,11 @@ FFI wrappers → `glide-core` → Valkey/Redis
     <entry>python/glide-async/Cargo.toml</entry>
     <bindings>python/glide-async/src/lib.rs</bindings>
     <client>python/glide-async/python/glide/glide_client.py</client>
-    <commands>python/glide-shared/glide_shared/commands/</commands>
+    <commands>python/glide-async/python/glide/async_commands/core.py</commands>
+    <standalone-commands>python/glide-async/python/glide/async_commands/standalone_commands.py</standalone-commands>
+    <cluster-commands>python/glide-async/python/glide/async_commands/cluster_commands.py</cluster-commands>
+    <shared-options>python/glide-shared/glide_shared/commands/</shared-options>
+    <errors>python/glide-shared/glide_shared/exceptions.py</errors>
     <tests>python/tests/</tests>
   </language>
   <language name="python-sync">
@@ -97,6 +262,7 @@ FFI wrappers → `glide-core` → Valkey/Redis
     <bindings>python/glide-sync/glide_sync/_glide_ffi.py</bindings>
     <client>python/glide-sync/glide_sync/glide_client.py</client>
     <commands>python/glide-sync/glide_sync/sync_commands/</commands>
+    <errors>python/glide-shared/glide_shared/exceptions.py</errors>
     <tests>python/tests/</tests>
   </language>
   <language name="java">
@@ -105,8 +271,12 @@ FFI wrappers → `glide-core` → Valkey/Redis
     <depends-on>core</depends-on>
     <entry>java/Cargo.toml</entry>
     <bindings>java/src/lib.rs</bindings>
-    <client>java/client/src/main/java/glide/api/</client>
+    <clients>java/client/src/main/java/glide/api/BaseClient.java, GlideClient.java, GlideClusterClient.java</clients>
     <commands>java/client/src/main/java/glide/api/commands/</commands>
+    <errors>java/client/src/main/java/glide/api/models/exceptions/</errors>
+    <unit-tests>java/client/src/test/java/glide/api/</unit-tests>
+    <integ-tests>java/integTest/src/test/java/glide/</integ-tests>
+    <jedis-compat>java/jedis-compatibility/</jedis-compat>
     <tests>java/client/src/test/java/glide/</tests>
   </language>
   <language name="node">
@@ -117,6 +287,7 @@ FFI wrappers → `glide-core` → Valkey/Redis
     <bindings>node/rust-client/src/lib.rs</bindings>
     <client>node/src/BaseClient.ts</client>
     <commands>node/src/Commands.ts</commands>
+    <errors>node/src/Errors.ts</errors>
     <tests>node/tests/</tests>
   </language>
   <language name="go">
@@ -127,6 +298,7 @@ FFI wrappers → `glide-core` → Valkey/Redis
     <bindings>go/callbacks.go</bindings>
     <client>go/base_client.go</client>
     <commands>go/internal/interfaces/</commands>
+    <errors>go/errors.go</errors>
     <tests>go/integTest/</tests>
   </language>
   <language name="core">
@@ -134,8 +306,13 @@ FFI wrappers → `glide-core` → Valkey/Redis
     <start-with>glide-core/src/client/mod.rs</start-with>
     <entry>glide-core/Cargo.toml</entry>
     <client>glide-core/src/client/mod.rs</client>
+    <request-types>glide-core/src/request_type.rs</request-types>
     <socket>glide-core/src/socket_listener.rs</socket>
+    <errors>glide-core/src/errors.rs</errors>
+    <reconnection>glide-core/src/client/reconnecting_connection.rs</reconnection>
     <protobuf>glide-core/src/protobuf/</protobuf>
+    <compression>glide-core/src/compression.rs</compression>
+    <pubsub>glide-core/src/pubsub/synchronizer.rs</pubsub>
     <tests>glide-core/tests/</tests>
   </language>
   <language name="ffi">
@@ -145,3 +322,15 @@ FFI wrappers → `glide-core` → Valkey/Redis
     <bindings>ffi/src/lib.rs</bindings>
   </language>
 </context-sources>
+
+## Protobuf Wire Protocol
+
+Three proto files define the client-core communication:
+
+| Proto File | Purpose | Key Types |
+|---|---|---|
+| `command_request.proto` | Command encoding | `RequestType` enum (200+ commands), `Command`, routing info |
+| `connection_request.proto` | Client configuration | `ConnectionRequest`, `ReadFrom`, `TlsMode`, `CompressionConfig`, `IamCredentials` |
+| `response.proto` | Response handling | `Response`, `RequestError`, `RequestErrorType`, `ConstantResponse` |
+
+**RequestType ID ranges:** Bitmap=1xx, Cluster=2xx, Connection=3xx, String=4xx, Generic=5xx, Set=6xx, Hash=7xx, List=8xx, SortedSet=9xx, Stream=10xx, HyperLogLog=11xx, Geo=12xx, Scripting=13xx, Server=14xx, PubSub=15xx.


### PR DESCRIPTION
## Summary

Enhances CLAUDE.md and AGENTS.md to make AI agents significantly more effective when working on the Valkey GLIDE codebase. The key improvements address the most common gaps agents encounter: not knowing the command implementation workflow, not finding error/test files quickly, and missing critical pitfalls.

### CLAUDE.md improvements:
- **New command implementation workflow** — step-by-step XML-structured guide with exact file paths for protobuf, Rust core, and all 4 language bindings (Java, Python, Node.js, Go)
- **Error hierarchy reference** — consistent error tree across all languages with file locations
- **Testing quick reference** — specific build/test/lint commands per language with options for single-test runs
- **Key subsystems catalog** — PubSub synchronizer, compression, IAM auth, socket listener, reconnection, cluster scan, Jedis compat, OpenTelemetry
- **Common pitfalls section** — flaky tests, cross-language consistency, DCO signoff, commit signing, large payloads, reference cycles
- **Protobuf wire protocol reference** — RequestType ID range conventions
- **Expanded context-sources** — added error files, config builders, request_type.rs, standalone/cluster command files, reconnection module

### AGENTS.md improvements:
- **Command implementation pattern** — concise step-by-step flow for the most common dev task
- **Error handling table** — error types with retryability guidance
- **Debugging quick reference** — symptom → likely cause → where to look table
- **Commit signing requirement** — was missing from agent guidance, required by CI
- **Fixed Node.js lint command** — `npx run lint:fix` → `npx eslint --fix .`
- **Enhanced quality gates** — added cluster/standalone testing, batch/transaction support checks
- **Added PR workflow links** — SUBMITTING_PRS.md and REVIEWING_PRS.md references

## Test plan
- [ ] Verify CLAUDE.md file paths are accurate against current repo structure
- [ ] Verify AGENTS.md build commands work as documented
- [ ] Confirm no functional code was changed (docs-only PR)