### PR TITLE
[pub-agent] ci: add PR auto-labeler for language, type, and size labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,50 @@
+# Configuration for actions/labeler@v5
+# Labels PRs based on files changed
+# Docs: https://github.com/actions/labeler
+
+"python 🐍":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "python/**"
+
+"java ☕":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "java/**"
+
+"node 🐢":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "node/**"
+
+"go 🏃":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "go/**"
+
+"Rust ⚙️":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "glide-core/**"
+          - "logger_core/**"
+          - "ffi/**"
+          - "Cargo.toml"
+          - "Cargo.lock"
+          - "deny.toml"
+
+"CI/CD ⚒️":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "**/*.md"
+          - "!CHANGELOG.md"
+
+benchmarks:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "benchmarks/**"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,175 @@
+name: PR Auto-Labeler
+
+# Automatically labels PRs based on:
+# 1. Files changed (language/component labels via actions/labeler)
+# 2. PR title conventional commit scope (language + type labels)
+# 3. PR size (lines changed -> size/* labels)
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  # Ensure all required labels exist (idempotent)
+  ensure-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create missing labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const requiredLabels = [
+              { name: 'go 🏃',      color: '00ADD8', description: 'Go client changes' },
+              { name: 'Rust ⚙️',    color: 'DEA584', description: 'Rust core/FFI changes' },
+              { name: 'CI/CD ⚒️',   color: 'FBCA04', description: 'CI/CD workflow changes' },
+              { name: 'benchmarks', color: 'D4C5F9', description: 'Benchmark changes' },
+            ];
+            const { data: existing } = await github.rest.issues.listLabelsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            const existingNames = new Set(existing.map(l => l.name));
+            for (const label of requiredLabels) {
+              if (!existingNames.has(label.name)) {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ...label,
+                });
+                core.info(`Created label: ${label.name}`);
+              }
+            }
+
+  # Label based on files changed
+  path-labeler:
+    needs: ensure-labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: false
+
+  # Label based on PR title (conventional commits) and size
+  title-and-size-labeler:
+    needs: ensure-labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label from PR title and size
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const title = pr.title;
+            const labels = new Set();
+
+            // --- Conventional commit scope -> language labels ---
+            // Matches: feat(java): ..., fix(core): ..., chore(node): ...
+            const scopeMatch = title.match(/^\w+\(([^)]+)\)\s*(!)?:/);
+            if (scopeMatch) {
+              const scope = scopeMatch[1].toLowerCase();
+              const scopeToLabel = {
+                'java':                 'java ☕',
+                'jedis-compatibility':  'java ☕',
+                'python':               'python 🐍',
+                'node':                 'node 🐢',
+                'go':                   'go 🏃',
+                'core':                 'Rust ⚙️',
+                'rust':                 'Rust ⚙️',
+                'ffi':                  'Rust ⚙️',
+              };
+              if (scopeToLabel[scope]) {
+                labels.add(scopeToLabel[scope]);
+              }
+            }
+
+            // Legacy format: [Java] ..., Python: ..., Go: ...
+            const legacyBracket = title.match(/^\[(\w+)\]/);
+            const legacyColon = title.match(/^(\w+)\s*:/);
+            const legacyScope = (legacyBracket && legacyBracket[1]) || (legacyColon && legacyColon[1]);
+            if (legacyScope && !scopeMatch) {
+              const langMap = {
+                'java':       'java ☕',
+                'python':     'python 🐍',
+                'node':       'node 🐢',
+                'nodejs':     'node 🐢',
+                'typescript': 'node 🐢',
+                'go':         'go 🏃',
+                'golang':     'go 🏃',
+                'rust':       'Rust ⚙️',
+                'core':       'Rust ⚙️',
+              };
+              const mapped = langMap[legacyScope.toLowerCase()];
+              if (mapped) labels.add(mapped);
+            }
+
+            // --- Conventional commit type -> type labels ---
+            const typeMatch = title.match(/^(\w+)(\([^)]*\))?\s*(!)?:/);
+            if (typeMatch) {
+              const commitType = typeMatch[1].toLowerCase();
+              const typeToLabel = {
+                'docs':     'documentation',
+                'doc':      'documentation',
+                'test':     null,  // don't auto-label test-only changes
+                'perf':     null,
+                'ci':       'CI/CD ⚒️',
+                'chore':    null,
+                'refactor': null,
+              };
+              if (commitType in typeToLabel && typeToLabel[commitType]) {
+                labels.add(typeToLabel[commitType]);
+              }
+            }
+
+            // --- PR size labels ---
+            const additions = pr.additions || 0;
+            const deletions = pr.deletions || 0;
+            const totalChanges = additions + deletions;
+
+            const sizeLabels = ['size/XS', 'size/S', 'size/M', 'size/L', 'size/XL', 'size/XXL'];
+            let sizeLabel;
+            if (totalChanges <= 10)        sizeLabel = 'size/XS';
+            else if (totalChanges <= 50)   sizeLabel = 'size/S';
+            else if (totalChanges <= 200)  sizeLabel = 'size/M';
+            else if (totalChanges <= 500)  sizeLabel = 'size/L';
+            else if (totalChanges <= 1000) sizeLabel = 'size/XL';
+            else                           sizeLabel = 'size/XXL';
+
+            // Remove stale size labels, add current one
+            const currentLabels = pr.labels.map(l => l.name);
+            for (const sl of sizeLabels) {
+              if (sl !== sizeLabel && currentLabels.includes(sl)) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name: sl,
+                });
+              }
+            }
+            labels.add(sizeLabel);
+
+            // --- Apply labels ---
+            // Filter out labels already present
+            const labelsToAdd = [...labels].filter(l => !currentLabels.includes(l));
+
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: labelsToAdd,
+              });
+              core.info(`Added labels: ${labelsToAdd.join(', ')}`);
+            } else {
+              core.info('No new labels to add');
+            }


### PR DESCRIPTION
## Summary

- Adds automated PR labeling via two new files: `.github/labeler.yml` and `.github/workflows/pr-labeler.yml`
- Fills the gap where issue templates and dependabot management label their PRs, but regular contributor PRs receive no automatic labels
- Three labeling strategies run in parallel on every PR open/sync/edit:
  - **Path-based**: `actions/labeler@v5` maps file changes to language labels (`python/**` -> `python`, `java/**` -> `java`, etc.)
  - **Title-based**: Parses conventional commit scopes (`feat(java):` -> `java`) and types (`docs:` -> `documentation`, `ci:` -> `CI/CD`)
  - **Size-based**: Calculates `size/XS` through `size/XXL` from total lines changed, auto-removes stale size labels on force-push

## Details

Labels applied:
| Source | Labels |
|--------|--------|
| Files in `python/` | `python` |
| Files in `java/` | `java` |
| Files in `node/` | `node` |
| Files in `go/` | `go` |
| Files in `glide-core/`, `ffi/`, `logger_core/` | `Rust` |
| Files in `.github/` | `CI/CD` |
| Files in `docs/`, `**/*.md` | `documentation` |
| Files in `benchmarks/` | `benchmarks` |
| PR title `feat(java):` | `java` |
| PR title `docs:` | `documentation` |
| PR size <= 10 lines | `size/XS` |
| PR size <= 50 | `size/S` |
| PR size <= 200 | `size/M` |
| PR size <= 500 | `size/L` |
| PR size <= 1000 | `size/XL` |
| PR size > 1000 | `size/XXL` |

Also includes idempotent label creation for labels that may not exist yet (`go`, `Rust`, `CI/CD`, `benchmarks`).

## Test plan

- [ ] Verify YAML is valid (validated locally with Python yaml parser)
- [ ] Open a test PR touching `java/` files -> should get `java` + `size/*` labels
- [ ] Open a test PR with title `feat(python): ...` -> should get `python` label
- [ ] Verify existing workflows (dependabot-management, stale) still function correctly (no conflicts)