### PR TITLE
[pub-agent] chore(tooling): add Rust Makefile targets, improve help & agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,26 +41,36 @@ This is the Valkey GLIDE mono-repository containing a Rust core (`glide-core`) a
 make all
 
 # Individual language builds
-make java          # Build Java client (release mode)
-make python        # Build Python async + sync clients (release mode)
-make node          # Build Node.js client (release mode)
-make go            # Build Go client
+make rust            # Build Rust core + FFI (release)
+make java            # Build Java client (release mode)
+make python          # Build Python async + sync clients (release mode)
+make node            # Build Node.js client (release mode)
+make go              # Build Go client
 
 # Testing
-make java-test     # Run Java integration tests
-make python-test   # Run Python tests
-make node-test     # Run Node.js tests
-make go-test       # Run Go tests
+make rust-test       # Run Rust unit tests (no server needed)
+make java-test       # Run Java integration tests
+make python-test     # Run Python tests
+make node-test       # Run Node.js tests
+make go-test         # Run Go tests
 
-# Linting
-make java-lint     # Run Java spotlessApply
-make python-lint   # Run Python linters via dev.py
-make node-lint     # Run Node.js linters
-make go-lint       # Run Go linters
+# Linting (individual)
+make rust-lint       # Run clippy on Rust code
+make java-lint       # Run Java spotlessApply
+make python-lint     # Run Python linters via dev.py
+make node-lint       # Run Node.js linters
+make go-lint         # Run Go linters
+
+# Linting & formatting (cross-language)
+make lint            # Run linters for ALL languages
+make fmt             # Auto-format Rust + JS/TS
+make rust-fmt        # Format Rust code only
+make rust-fmt-check  # Check Rust formatting (no changes)
 
 # Utilities
-make clean         # Remove .build/ directory
-make help          # List available targets
+make info            # Show installed toolchain versions
+make clean           # Remove .build/ directory
+make help            # List all targets with descriptions
 ```
 
 ### Raw Equivalents Per Stack
@@ -204,14 +214,16 @@ valkey-glide/
 
 ## Quality Gates (Agent Checklist)
 
-- [ ] Build passes: `make all` succeeds
-- [ ] Lint passes: `make *-lint` targets succeed
-- [ ] Tests pass: `make *-test` targets succeed
+- [ ] Build passes: `make all` succeeds (or `make <lang>` for single-language changes)
+- [ ] Lint passes: `make lint` (all languages) or `make <lang>-lint`
+- [ ] Tests pass: `make <lang>-test` for affected languages
+- [ ] Rust core: `make rust-lint && make rust-fmt-check && make rust-test`
 - [ ] No generated outputs committed (check `.gitignore`)
 - [ ] DCO signoff present: `git log --format="%B" -n 1 | grep "Signed-off-by"`
 - [ ] Conventional commit format used
 - [ ] Cross-language API consistency maintained
 - [ ] Security scan passes (no secrets committed)
+- [ ] Verify toolchain: `make info` to confirm versions match CI expectations
 
 ## Quick Facts for Reasoners
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,73 @@ docs/           # Documentation
 Socket IPC wrappers → `socket_listener` → `glide-core` → Valkey/Redis
 FFI wrappers → `glide-core` → Valkey/Redis
 
+## Quick Dev Commands
+
+```bash
+make help          # List all targets with descriptions
+make info          # Show installed toolchain versions
+make rust          # Build Rust core + FFI (release)
+make rust-test     # Run Rust unit tests (no server needed)
+make rust-lint     # Run clippy on all Rust crates
+make rust-fmt      # Format all Rust code
+make lint          # Run linters for ALL languages
+make fmt           # Auto-format Rust + JS/TS
+```
+
+## How to Add a New Valkey Command
+
+<command-checklist>
+  <step n="1" where="glide-core/src/protobuf/command_request.proto">
+    Add variant to `RequestType` enum. Use next available number in the correct category block.
+  </step>
+  <step n="2" where="glide-core/src/client/mod.rs">
+    Map the new `RequestType` to the actual Redis command string in the `get_command` match arm.
+  </step>
+  <step n="3" where="language wrapper (pick one)">
+    Add the public API method to the language client:
+    - Node: `node/src/Commands.ts` (createXxx function) + `node/src/BaseClient.ts` (method)
+    - Python async: `python/glide-shared/glide_shared/commands/` (trait) + `python/glide-async/python/glide/glide_client.py`
+    - Python sync: `python/glide-sync/glide_sync/sync_commands/` + `python/glide-sync/glide_sync/glide_client.py`
+    - Java: `java/client/src/main/java/glide/api/commands/` (interface) + `java/client/src/main/java/glide/api/BaseClient.java`
+    - Go: `go/internal/interfaces/` (interface) + `go/base_client.go`
+  </step>
+  <step n="4" where="tests">
+    Add integration tests using a live Valkey/Redis server. Minimum: standalone + cluster mode.
+  </step>
+  <step n="5" where="docs">
+    Update command docs/examples if the command is user-facing.
+  </step>
+</command-checklist>
+
+## Troubleshooting
+
+<troubleshooting>
+  <issue name="protobuf-out-of-sync">
+    <symptom>Unknown RequestType variant, missing field, or stale protobuf</symptom>
+    <fix>Rebuild protobuf: `cd glide-core && cargo build` (Rust auto-generates). For Go: `cd go && make generate-protobuf`. For Node: `cd node && npm run build`.</fix>
+  </issue>
+  <issue name="rust-build-fails">
+    <symptom>Cargo build errors in glide-core or ffi</symptom>
+    <fix>Check `rustc --version` (need 1.75+). Run `cargo clean` in the failing crate, then rebuild. Check if `redis-rs` submodule is initialized: `git submodule update --init`.</fix>
+  </issue>
+  <issue name="node-native-module">
+    <symptom>Node.js "Cannot find module ../build-ts/native" or NAPI errors</symptom>
+    <fix>`cd node && npm run build` to compile Rust native module. If stale: `rm -rf node/build-ts node/rust-client/target && npm run build`.</fix>
+  </issue>
+  <issue name="java-jni-load">
+    <symptom>UnsatisfiedLinkError or JNI library not found</symptom>
+    <fix>`cd java && ./gradlew :client:buildAllRelease` to rebuild the native library. Check `java -version` matches the expected JDK (21+).</fix>
+  </issue>
+  <issue name="test-needs-server">
+    <symptom>Integration tests fail with connection refused</symptom>
+    <fix>Start a Valkey/Redis server: `valkey-server --port 6379` or use `python3 utils/cluster_manager.py start` for standalone, add `--cluster-mode` for cluster.</fix>
+  </issue>
+  <issue name="go-ffi-missing">
+    <symptom>Go build fails with missing `libglide_ffi.a` or `lib.h`</symptom>
+    <fix>`cd go && make build-glide-client` builds the FFI static lib and generates C headers. Requires `cbindgen` (`cargo install cbindgen`).</fix>
+  </issue>
+</troubleshooting>
+
 ## Context Retrieval
 
 <context-sources>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ make fmt           # Auto-format Rust + JS/TS
   </issue>
   <issue name="java-jni-load">
     <symptom>UnsatisfiedLinkError or JNI library not found</symptom>
-    <fix>`cd java && ./gradlew :client:buildAllRelease` to rebuild the native library. Check `java -version` matches the expected JDK (21+).</fix>
+    <fix>`cd java && ./gradlew :client:buildAllRelease` to rebuild the native library. Check `java -version` matches the expected JDK (11+).</fix>
   </issue>
   <issue name="test-needs-server">
     <symptom>Integration tests fail with connection refused</symptom>

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
-.PHONY: all java java-test python python-test node node-test check-valkey-server go go-test prettier-check prettier-fix
+.PHONY: all java java-test python python-test node node-test check-valkey-server go go-test \
+	prettier-check prettier-fix rust rust-test rust-lint rust-fmt lint fmt info
 
 BLUE=\033[34m
 YELLOW=\033[33m
 GREEN=\033[32m
+RED=\033[31m
+CYAN=\033[36m
+BOLD=\033[1m
 RESET=\033[0m
 ROOT_DIR=$(shell pwd)
 PYENV_DIR=$(shell pwd)/python/.env
@@ -100,14 +104,106 @@ go-lint: .build/go_deps
 	@mkdir -p .build/ && touch .build/go_deps
 
 ##
+## Rust targets
+##
+rust: ## Build glide-core and FFI (release)
+	@echo "$(GREEN)Building Rust core + FFI (release)$(RESET)"
+	@cd glide-core && cargo build --release
+	@cd ffi && cargo build --release
+
+rust-test: ## Run Rust unit tests
+	@echo "$(GREEN)Running Rust tests$(RESET)"
+	@cd glide-core && cargo test
+	@cd ffi && cargo test
+
+rust-lint: ## Run clippy on Rust code
+	@echo "$(GREEN)Running clippy$(RESET)"
+	@cd glide-core && cargo clippy -- -D warnings
+	@cd ffi && cargo clippy -- -D warnings
+
+rust-fmt: ## Format Rust code
+	@echo "$(GREEN)Formatting Rust code$(RESET)"
+	@cd glide-core && cargo fmt
+	@cd ffi && cargo fmt
+	@cd logger_core && cargo fmt
+
+rust-fmt-check: ## Check Rust formatting without changes
+	@echo "$(GREEN)Checking Rust formatting$(RESET)"
+	@cd glide-core && cargo fmt -- --check
+	@cd ffi && cargo fmt -- --check
+	@cd logger_core && cargo fmt -- --check
+
+##
+## Cross-language targets
+##
+lint: rust-lint python-lint java-lint node-lint go-lint ## Run linters for all languages
+	@echo "$(GREEN)All linters passed$(RESET)"
+
+fmt: rust-fmt prettier-fix ## Auto-format Rust + JS/TS files
+	@echo "$(GREEN)All formatters applied$(RESET)"
+
+##
 ## Common targets
 ##
 check-valkey-server:
 	which valkey-server || which redis-server
 
-clean:
+clean: ## Remove build caches
 	rm -fr .build/
 
-help:
-	@echo "$(GREEN)Listing Makefile targets:$(RESET)"
-	@echo $(shell grep '^[^#[:space:]].*:' Makefile|cut -d":" -f1|grep -v PHONY|grep -v "^.build"|sort)
+info: ## Show development environment info
+	@echo "$(BOLD)$(CYAN)Valkey GLIDE Development Environment$(RESET)"
+	@echo ""
+	@echo "$(BOLD)Toolchain versions:$(RESET)"
+	@printf "  Rust:    " && (rustc --version 2>/dev/null || echo "$(RED)not installed$(RESET)")
+	@printf "  Cargo:   " && (cargo --version 2>/dev/null || echo "$(RED)not installed$(RESET)")
+	@printf "  Java:    " && (java --version 2>/dev/null | head -1 || echo "$(RED)not installed$(RESET)")
+	@printf "  Gradle:  " && (cd java && ./gradlew --version 2>/dev/null | grep "Gradle " || echo "$(RED)not available$(RESET)")
+	@printf "  Python:  " && (python3 --version 2>/dev/null || echo "$(RED)not installed$(RESET)")
+	@printf "  Node.js: " && (node --version 2>/dev/null || echo "$(RED)not installed$(RESET)")
+	@printf "  npm:     " && (npm --version 2>/dev/null || echo "$(RED)not installed$(RESET)")
+	@printf "  Go:      " && (go version 2>/dev/null || echo "$(RED)not installed$(RESET)")
+	@printf "  Protoc:  " && (protoc --version 2>/dev/null || echo "$(RED)not installed$(RESET)")
+	@echo ""
+	@printf "  Server:  " && (valkey-server --version 2>/dev/null || redis-server --version 2>/dev/null || echo "$(RED)no valkey-server or redis-server found$(RESET)")
+	@echo ""
+	@echo "$(BOLD)Key paths:$(RESET)"
+	@echo "  Root:    $(ROOT_DIR)"
+	@echo "  Core:    $(ROOT_DIR)/glide-core"
+	@echo "  FFI:     $(ROOT_DIR)/ffi"
+
+help: ## Show this help
+	@echo "$(BOLD)$(CYAN)Valkey GLIDE - Makefile Targets$(RESET)"
+	@echo ""
+	@echo "$(BOLD)Build targets:$(RESET)"
+	@echo "  $(GREEN)all$(RESET)             Build and test all languages"
+	@echo "  $(GREEN)rust$(RESET)            Build Rust core + FFI (release)"
+	@echo "  $(GREEN)java$(RESET)            Build Java client (release)"
+	@echo "  $(GREEN)python$(RESET)          Build Python async + sync clients (release)"
+	@echo "  $(GREEN)node$(RESET)            Build Node.js client (release)"
+	@echo "  $(GREEN)go$(RESET)              Build Go client"
+	@echo ""
+	@echo "$(BOLD)Test targets:$(RESET)"
+	@echo "  $(GREEN)rust-test$(RESET)       Run Rust unit tests"
+	@echo "  $(GREEN)java-test$(RESET)       Run Java integration tests"
+	@echo "  $(GREEN)python-test$(RESET)     Run Python tests"
+	@echo "  $(GREEN)node-test$(RESET)       Run Node.js tests"
+	@echo "  $(GREEN)go-test$(RESET)         Run Go tests"
+	@echo ""
+	@echo "$(BOLD)Lint & format targets:$(RESET)"
+	@echo "  $(GREEN)lint$(RESET)            Run linters for all languages"
+	@echo "  $(GREEN)fmt$(RESET)             Auto-format Rust + JS/TS"
+	@echo "  $(GREEN)rust-lint$(RESET)       Run clippy on Rust code"
+	@echo "  $(GREEN)rust-fmt$(RESET)        Format Rust code"
+	@echo "  $(GREEN)rust-fmt-check$(RESET)  Check Rust formatting (no changes)"
+	@echo "  $(GREEN)java-lint$(RESET)       Run Java spotlessApply"
+	@echo "  $(GREEN)python-lint$(RESET)     Run Python linters"
+	@echo "  $(GREEN)node-lint$(RESET)       Run Node.js linters"
+	@echo "  $(GREEN)go-lint$(RESET)         Run Go linters"
+	@echo "  $(GREEN)prettier-check$(RESET)  Check JS/TS formatting"
+	@echo "  $(GREEN)prettier-fix$(RESET)    Fix JS/TS formatting"
+	@echo ""
+	@echo "$(BOLD)Utility targets:$(RESET)"
+	@echo "  $(GREEN)info$(RESET)            Show development environment info"
+	@echo "  $(GREEN)clean$(RESET)           Remove build caches"
+	@echo "  $(GREEN)help$(RESET)            Show this help"


### PR DESCRIPTION
## Summary

- **Makefile**: Added missing Rust targets (`rust`, `rust-test`, `rust-lint`, `rust-fmt`, `rust-fmt-check`), cross-language meta-targets (`lint`, `fmt`), environment info target (`info`), and a proper categorized `help` output
- **CLAUDE.md**: Added Quick Dev Commands reference, step-by-step "How to Add a New Command" checklist, and Troubleshooting section covering common build/test issues across all languages
- **AGENTS.md**: Updated build rules to document new targets, improved Quality Gates checklist with Rust-specific checks

## Motivation

The Rust core (glide-core, ffi, logger_core) had no top-level Makefile targets despite being the foundation of all language bindings. The old `make help` just listed target names with no descriptions. CLAUDE.md lacked actionable troubleshooting and onboarding guidance for agents adding new commands.

## Test plan

- [x] `make help` displays categorized target listing
- [x] `make info` shows toolchain versions
- [x] `make -n rust`, `make -n rust-test`, `make -n rust-lint`, `make -n rust-fmt`, `make -n rust-fmt-check` all resolve correctly
- [x] `make -n lint` chains all language linters
- [x] `make -n fmt` chains Rust formatter + Prettier
- [x] No functional changes to existing targets