### PR TITLE
Unify OTel span raw-pointer lifecycle into shared glide_core helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changes
 
+* Core, Java, Node, Python: Unify the OpenTelemetry span raw-pointer lifecycle across all bindings into shared `glide_core` helpers (`leak_span` / `drop_span_ptr`), replacing per-binding copies of the `Arc::into_raw` create and `Arc::from_raw` drop logic so the create/drop path is exercised by a single leak-regression test. No public API or behavior change.
 * Core, Python, Java, Node, Go: Add `SAVE`, `BGSAVE` and `BGREWRITEAOF` command support ([#6095](https://github.com/valkey-io/valkey-glide/issues/6095))
 * Java: Add `FAILOVER` and `REPLICAOF` command support ([#6170](https://github.com/valkey-io/valkey-glide/pull/6170))
 * Core, Java, Python, Node, Go: Add client-wide circuit breaker that detects sustained error rates and rejects requests at the FFI boundary before threads park. Opt-in via `ClientCircuitBreakerConfiguration`. Tracks error rate in a sliding window, trips when threshold is exceeded, and recovers automatically via optimistic HalfOpen with consecutive success validation. Java additionally performs a synchronous pre-check to prevent thread explosion under `managedBlock()`. ([#5996](https://github.com/valkey-io/valkey-glide/issues/5996))

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -3872,9 +3872,7 @@ pub extern "C" fn create_otel_span(request_type: RequestType) -> u64 {
 
     // Create span and convert to pointer
     let span = GlideOpenTelemetry::new_span(&command_name);
-    let arc = Arc::new(span);
-    let ptr = Arc::into_raw(arc);
-    let span_ptr = ptr as u64;
+    let span_ptr = GlideOpenTelemetry::leak_span(span);
 
     logger_core::log_debug(
         "ffi_otel",
@@ -3893,9 +3891,7 @@ pub extern "C" fn create_batch_otel_span() -> u64 {
 
     // Create span and convert to pointer
     let span = GlideOpenTelemetry::new_span(command_name);
-    let arc = Arc::new(span);
-    let ptr = Arc::into_raw(arc);
-    let span_ptr = ptr as u64;
+    let span_ptr = GlideOpenTelemetry::leak_span(span);
 
     logger_core::log_debug(
         "ffi_otel",
@@ -3931,9 +3927,7 @@ pub unsafe extern "C" fn create_batch_otel_span_with_parent(parent_span_ptr: u64
         );
         // Graceful fallback: create independent batch span
         let span = GlideOpenTelemetry::new_span(command_name);
-        let arc = Arc::new(span);
-        let ptr = Arc::into_raw(arc);
-        let span_ptr = ptr as u64;
+        let span_ptr = GlideOpenTelemetry::leak_span(span);
         logger_core::log_debug(
             "ffi_otel",
             format!(
@@ -3974,9 +3968,7 @@ pub unsafe extern "C" fn create_batch_otel_span_with_parent(parent_span_ptr: u64
     };
 
     // Convert span to pointer and return
-    let arc = Arc::new(span);
-    let ptr = Arc::into_raw(arc);
-    let span_ptr = ptr as u64;
+    let span_ptr = GlideOpenTelemetry::leak_span(span);
 
     logger_core::log_debug(
         "ffi_otel",
@@ -4053,9 +4045,7 @@ pub unsafe extern "C" fn create_named_otel_span(span_name: *const c_char) -> u64
 
     // Create the named span using existing new_span method
     let span = GlideOpenTelemetry::new_span(name_str);
-    let arc = Arc::new(span);
-    let ptr = Arc::into_raw(arc);
-    let span_ptr = ptr as u64;
+    let span_ptr = GlideOpenTelemetry::leak_span(span);
 
     logger_core::log_debug(
         "ffi_otel",
@@ -4097,9 +4087,7 @@ pub unsafe extern "C" fn create_otel_span_with_parent(
         );
         // Graceful fallback: create independent span
         let span = GlideOpenTelemetry::new_span(&command_name);
-        let arc = Arc::new(span);
-        let ptr = Arc::into_raw(arc);
-        let span_ptr = ptr as u64;
+        let span_ptr = GlideOpenTelemetry::leak_span(span);
         logger_core::log_debug(
             "ffi_otel",
             format!(
@@ -4140,9 +4128,7 @@ pub unsafe extern "C" fn create_otel_span_with_parent(
     };
 
     // Convert span to pointer and return
-    let arc = Arc::new(span);
-    let ptr = Arc::into_raw(arc);
-    let span_ptr = ptr as u64;
+    let span_ptr = GlideOpenTelemetry::leak_span(span);
 
     logger_core::log_debug(
         "ffi_otel",
@@ -4159,66 +4145,22 @@ pub unsafe extern "C" fn create_otel_span_with_parent(
 /// * `span_ptr` must be a valid pointer to a [`Arc<GlideSpan>`] span created by [`create_otel_span`] or `0`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn drop_otel_span(span_ptr: u64) {
-    // Validate span pointer
     if span_ptr == 0 {
         logger_core::log_debug("ffi_otel", "drop_otel_span: Ignoring null span pointer (0)");
         return;
     }
 
-    // Validate pointer alignment and bounds (basic safety checks)
-    if !span_ptr.is_multiple_of(8) {
-        logger_core::log_error(
+    // Pointer validation, panic containment, and Arc reclamation live in the shared
+    // glide_core helper so the C FFI and Java/JNI bindings exercise one tested code path.
+    match unsafe { GlideOpenTelemetry::drop_span_ptr(span_ptr) } {
+        Ok(()) => logger_core::log_debug(
             "ffi_otel",
-            format!("drop_otel_span: Invalid span pointer - misaligned: 0x{span_ptr:x}",),
-        );
-        return;
-    }
-
-    // Check for obviously invalid pointer values
-    const MIN_VALID_ADDRESS: u64 = 0x1000; // 4KB, below this is likely invalid
-    const MAX_VALID_ADDRESS: u64 = 0x7FFF_FFFF_FFFF_FFF8; // Max user space on most 64-bit systems
-
-    if span_ptr < MIN_VALID_ADDRESS {
-        logger_core::log_error(
+            format!("drop_otel_span: Successfully dropped span with pointer 0x{span_ptr:x}"),
+        ),
+        Err(e) => logger_core::log_error(
             "ffi_otel",
-            format!("drop_otel_span: Invalid span pointer - address too low: 0x{span_ptr:x}",),
-        );
-        return;
-    }
-
-    if span_ptr > MAX_VALID_ADDRESS {
-        logger_core::log_error(
-            "ffi_otel",
-            format!("drop_otel_span: Invalid span pointer - address too high: 0x{span_ptr:x}",),
-        );
-        return;
-    }
-
-    // Attempt to safely drop the span
-    unsafe {
-        // Use std::panic::catch_unwind to handle potential panics during Arc::from_raw
-        let result = std::panic::catch_unwind(|| {
-            Arc::from_raw(span_ptr as *const GlideSpan);
-        });
-
-        match result {
-            Ok(_) => {
-                logger_core::log_debug(
-                    "ffi_otel",
-                    format!(
-                        "drop_otel_span: Successfully dropped span with pointer 0x{span_ptr:x}",
-                    ),
-                );
-            }
-            Err(_) => {
-                logger_core::log_error(
-                    "ffi_otel",
-                    format!(
-                        "drop_otel_span: Panic occurred while dropping span pointer 0x{span_ptr:x} - likely invalid pointer",
-                    ),
-                );
-            }
-        }
+            format!("drop_otel_span: Failed to drop span pointer 0x{span_ptr:x}: {e}"),
+        ),
     }
 }
 

--- a/glide-core/telemetry/src/open_telemetry.rs
+++ b/glide-core/telemetry/src/open_telemetry.rs
@@ -706,6 +706,63 @@ impl GlideOpenTelemetry {
         Ok(span)
     }
 
+    /// Leak a [`GlideSpan`] into a raw `u64` pointer for transfer across an FFI/JNI boundary.
+    ///
+    /// The span is moved into a fresh [`Arc`] and converted to a raw pointer via
+    /// [`Arc::into_raw`], leaving its strong count at 1 (owned by the returned pointer). The
+    /// caller is responsible for eventually passing the pointer to [`drop_span_ptr`] exactly
+    /// once to reclaim it; failing to do so leaks the span.
+    ///
+    /// This is the single shared create path used by both the C FFI (`glide-ffi`) and the
+    /// Java/JNI (`glide-rs`) bindings, so the leak behaviour is exercised by one test.
+    ///
+    /// [`drop_span_ptr`]: GlideOpenTelemetry::drop_span_ptr
+    pub fn leak_span(span: GlideSpan) -> u64 {
+        Arc::into_raw(Arc::new(span)) as u64
+    }
+
+    /// Reclaim and drop a span previously leaked by [`leak_span`].
+    ///
+    /// Validates the pointer with [`is_span_pointer_valid`] before reconstructing the
+    /// [`Arc`] via [`Arc::from_raw`] and dropping it, releasing the span's native
+    /// allocation. A `0` pointer is treated as a no-op success (matching the bindings'
+    /// "ignore null span" behaviour). Any panic during reclamation is contained and
+    /// reported as an error rather than unwinding across the FFI boundary.
+    ///
+    /// This is the single shared drop path used by both the C FFI (`glide-ffi`) and the
+    /// Java/JNI (`glide-rs`) bindings; a missed reclamation in either binding is caught by
+    /// the helper's own test rather than going unobserved.
+    ///
+    /// # Safety
+    /// `span_ptr` must be `0`, or a pointer returned by [`leak_span`] that has not already
+    /// been passed to this function (no double free).
+    ///
+    /// [`leak_span`]: GlideOpenTelemetry::leak_span
+    /// [`is_span_pointer_valid`]: GlideOpenTelemetry::is_span_pointer_valid
+    pub unsafe fn drop_span_ptr(span_ptr: u64) -> Result<(), TraceError> {
+        // A null pointer means "no span was created" (e.g. sampling skipped it); not an error.
+        if span_ptr == 0 {
+            return Ok(());
+        }
+
+        if !unsafe { Self::is_span_pointer_valid(span_ptr) } {
+            return Err(TraceError::from(format!(
+                "Invalid span pointer: 0x{span_ptr:x} failed validation checks"
+            )));
+        }
+
+        // Contain any panic from Arc::from_raw so it never unwinds across the FFI/JNI boundary.
+        let result = std::panic::catch_unwind(|| unsafe {
+            drop(Arc::from_raw(span_ptr as *const GlideSpan));
+        });
+
+        result.map_err(|_| {
+            TraceError::from(format!(
+                "Panic occurred while dropping span pointer 0x{span_ptr:x} - likely invalid pointer"
+            ))
+        })
+    }
+
     /// Initialise the open telemetry library with a file system exporter
     ///
     /// This method should be called once for the given **process**
@@ -1258,6 +1315,62 @@ mod tests {
             assert_eq!(span.get_reference_count(), 2);
             drop(span);
         });
+    }
+
+    /// Leak a span into a raw pointer and reclaim it via the shared `drop_span_ptr` helper,
+    /// asserting the span's `Arc` strong count returns to baseline. This guards the shared
+    /// create/drop path that BOTH the C FFI (`glide-ffi`) and the Java/JNI (`glide-rs`)
+    /// bindings route through: a leak *inside* the helper would leave the count elevated.
+    /// (Whether each binding call site actually invokes the helper is a separate, per-binding
+    /// concern not covered here.)
+    #[test]
+    fn test_leak_and_drop_span_ptr_does_not_leak() {
+        // No init_otel()/exporter needed: this asserts on the Arc strong count, not exported
+        // spans, so it stays independent of the shared global OTel state other tests use.
+        for i in 0..1000 {
+            let span_ptr = GlideOpenTelemetry::leak_span(GlideOpenTelemetry::new_span("loop"));
+            assert_ne!(span_ptr, 0, "leak_span should produce a non-null pointer");
+
+            // Co-own the leaked Arc so we can observe the strong count across drop_span_ptr,
+            // without stealing the reference owned by the leaked pointer.
+            let owner = unsafe {
+                Arc::increment_strong_count(span_ptr as *const GlideSpan);
+                Arc::from_raw(span_ptr as *const GlideSpan)
+            };
+            assert_eq!(
+                Arc::strong_count(&owner),
+                2,
+                "iteration {i}: leaked pointer + test co-owner"
+            );
+
+            unsafe {
+                GlideOpenTelemetry::drop_span_ptr(span_ptr)
+                    .expect("dropping a valid span pointer should succeed");
+            }
+
+            assert_eq!(
+                Arc::strong_count(&owner),
+                1,
+                "iteration {i}: drop_span_ptr must release the leaked reference (no leak)"
+            );
+            // `owner` is dropped here, fully reclaiming the span before the next iteration.
+        }
+    }
+
+    /// `drop_span_ptr` treats a null pointer as a no-op success and rejects obviously invalid
+    /// pointers with an error instead of dereferencing them.
+    #[test]
+    fn test_drop_span_ptr_null_and_invalid() {
+        // Null pointer: "no span was created" — not an error, no allocation touched.
+        assert!(unsafe { GlideOpenTelemetry::drop_span_ptr(0) }.is_ok());
+
+        // Obviously invalid pointers must be rejected without dereferencing them.
+        for invalid in [0x1u64, 0x1001, 0x800, 0xDEAD_BEEF, 0xFFFF_FFFF_FFFF_FFFF] {
+            assert!(
+                unsafe { GlideOpenTelemetry::drop_span_ptr(invalid) }.is_err(),
+                "invalid pointer 0x{invalid:x} should be rejected"
+            );
+        }
     }
 
     #[test]

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -308,11 +308,10 @@ async fn execute_command_request_and_complete(
                     } {
                         Ok(span) => {
                             span.end();
-                            unsafe {
-                                std::sync::Arc::from_raw(
-                                    root_span_ptr as *const glide_core::GlideSpan,
-                                );
-                            }
+                            // Reclaim via the shared helper (pointer already validated above).
+                            let _ = unsafe {
+                                glide_core::GlideOpenTelemetry::drop_span_ptr(root_span_ptr)
+                            };
                         }
                         Err(err) => {
                             log_warn_lazy!(
@@ -420,11 +419,10 @@ async fn execute_command_request_and_complete(
                     } {
                         Ok(root_span) => {
                             root_span.end();
-                            unsafe {
-                                std::sync::Arc::from_raw(
-                                    root_span_ptr as *const glide_core::GlideSpan,
-                                );
-                            }
+                            // Reclaim via the shared helper (pointer already validated above).
+                            let _ = unsafe {
+                                glide_core::GlideOpenTelemetry::drop_span_ptr(root_span_ptr)
+                            };
                         }
                         Err(err) => {
                             log_warn_lazy!(
@@ -1369,8 +1367,8 @@ pub extern "system" fn Java_glide_ffi_resolvers_OpenTelemetryResolver_createLeak
         ) -> Result<jlong, FFIError> {
             let name_str: String = env.get_string(&name)?.into();
             let span = glide_core::GlideOpenTelemetry::new_span(&name_str);
-            let s = Arc::into_raw(Arc::new(span)) as *mut glide_core::GlideSpan;
-            Ok(s as jlong)
+            // Shared create path with the C FFI binding; see glide_core::GlideOpenTelemetry::leak_span.
+            Ok(glide_core::GlideOpenTelemetry::leak_span(span) as jlong)
         }
         let result = create_leaked_otel_span(&mut env, name);
         handle_errors(&mut env, result)
@@ -1392,23 +1390,18 @@ pub unsafe extern "system" fn Java_glide_ffi_resolvers_OpenTelemetryResolver_dro
 ) {
     run_ffi(|| {
         fn drop_otel_span(span_ptr: jlong) -> Result<(), FFIError> {
+            // The JNI contract rejects a 0/negative pointer as an error (unlike the shared
+            // helper, which treats 0 as a no-op), so guard it before delegating.
             if span_ptr <= 0 {
                 return Err(FFIError::OpenTelemetry(
                     "Received an invalid pointer value.".to_string(),
                 ));
             }
 
-            let span_ptr_u64 = span_ptr as u64;
-            if unsafe { !glide_core::GlideOpenTelemetry::is_span_pointer_valid(span_ptr_u64) } {
-                return Err(FFIError::OpenTelemetry(format!(
-                    "Received an invalid pointer value: {span_ptr}"
-                )));
-            }
-
-            unsafe {
-                Arc::from_raw(span_ptr as *const glide_core::GlideSpan);
-            }
-            Ok(())
+            // Shared validate + reclaim path with the C FFI binding; see
+            // glide_core::GlideOpenTelemetry::drop_span_ptr.
+            unsafe { glide_core::GlideOpenTelemetry::drop_span_ptr(span_ptr as u64) }
+                .map_err(|e| FFIError::OpenTelemetry(e.to_string()))
         }
         let result = drop_otel_span(span_ptr);
         handle_errors(&mut env, result)
@@ -1856,11 +1849,12 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeBatchAsync(
                                 } {
                                     Ok(root_span) => {
                                         root_span.end();
-                                        unsafe {
-                                            std::sync::Arc::from_raw(
-                                                root_span_ptr as *const glide_core::GlideSpan,
-                                            );
-                                        }
+                                        // Reclaim via the shared helper (pointer already validated above).
+                                        let _ = unsafe {
+                                            glide_core::GlideOpenTelemetry::drop_span_ptr(
+                                                root_span_ptr,
+                                            )
+                                        };
                                     }
                                     Err(err) => {
                                         log_warn_lazy!(

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -551,8 +551,8 @@ pub fn create_leaked_double(float: f64) -> [u32; 2] {
 #[napi(ts_return_type = "[number, number]")]
 pub fn create_leaked_otel_span(name: String) -> [u32; 2] {
     let span = GlideOpenTelemetry::new_span(&name);
-    let s = Arc::into_raw(Arc::new(span)) as *mut GlideSpan;
-    split_pointer(s)
+    // Shared create path with the other bindings; see glide_core::GlideOpenTelemetry::leak_span.
+    split_pointer(GlideOpenTelemetry::leak_span(span) as *mut GlideSpan)
 }
 
 /// Creates an open telemetry span with the given name as a child of a remote span context.
@@ -584,13 +584,15 @@ pub fn create_otel_span_with_trace_context(
             GlideOpenTelemetry::new_span(&name)
         }
     };
-    let s = Arc::into_raw(Arc::new(span)) as *mut GlideSpan;
-    split_pointer(s)
+    // Shared create path with the other bindings; see glide_core::GlideOpenTelemetry::leak_span.
+    split_pointer(GlideOpenTelemetry::leak_span(span) as *mut GlideSpan)
 }
 
 #[napi]
 pub fn drop_otel_span(span_ptr: BigInt) {
     let (is_negative, span_ptr, lossless) = span_ptr.get_u64();
+    // The BigInt conversion guards are specific to this binding; 0 is rejected here (unlike the
+    // shared helper, which treats it as a no-op) to preserve existing behaviour.
     let error_msg = if is_negative {
         "Received a negative pointer value."
     } else if !lossless {
@@ -598,7 +600,14 @@ pub fn drop_otel_span(span_ptr: BigInt) {
     } else if span_ptr == 0 {
         "Received a zero pointer value."
     } else {
-        unsafe { Arc::from_raw(span_ptr as *const GlideSpan) };
+        // Shared validate + reclaim path; see glide_core::GlideOpenTelemetry::drop_span_ptr.
+        if let Err(e) = unsafe { GlideOpenTelemetry::drop_span_ptr(span_ptr) } {
+            log(
+                Level::Error,
+                "OpenTelemetry".to_string(),
+                format!("Failed to drop span. {e}"),
+            );
+        }
         return;
     };
 

--- a/python/glide-async/src/lib.rs
+++ b/python/glide-async/src/lib.rs
@@ -9,7 +9,7 @@ use glide_core::errors::error_message;
 use glide_core::start_socket_listener;
 use glide_core::{
     DEFAULT_FLUSH_SIGNAL_INTERVAL_MS, DEFAULT_TRACE_SAMPLE_PERCENTAGE, GlideOpenTelemetry,
-    GlideOpenTelemetrySignalsExporter, GlideSpan,
+    GlideOpenTelemetrySignalsExporter,
 };
 use pyo3::Python;
 use pyo3::exceptions::PyTypeError;
@@ -669,12 +669,14 @@ fn get_cache_metric_from_registry(
 #[pyfunction]
 pub fn create_otel_span(name: String) -> usize {
     let span = GlideOpenTelemetry::new_span(&name);
-    let s = Arc::into_raw(Arc::new(span)) as *mut GlideSpan;
-    s as usize
+    // Shared create path with the other bindings; see glide_core::GlideOpenTelemetry::leak_span.
+    GlideOpenTelemetry::leak_span(span) as usize
 }
 
 #[pyfunction]
 pub fn drop_otel_span(span_ptr: usize) {
+    // 0 is rejected here (unlike the shared helper, which treats it as a no-op) to preserve
+    // existing behaviour.
     if span_ptr == 0 {
         log(
             Level::Error,
@@ -684,8 +686,13 @@ pub fn drop_otel_span(span_ptr: usize) {
         return;
     }
 
-    unsafe {
-        Arc::from_raw(span_ptr as *const GlideSpan);
+    // Shared validate + reclaim path; see glide_core::GlideOpenTelemetry::drop_span_ptr.
+    if let Err(e) = unsafe { GlideOpenTelemetry::drop_span_ptr(span_ptr as u64) } {
+        log(
+            Level::Error,
+            "OpenTelemetry".to_string(),
+            format!("Failed to drop span. {e}"),
+        );
     }
 }
 


### PR DESCRIPTION
### Summary

Every native binding (C FFI, JNI, NAPI, PyO3) maintained its own copy of the OpenTelemetry span raw-pointer lifecycle — `Arc::into_raw` on create, `Arc::from_raw` on drop. A leak fix or regression test on one binding's copy did not protect the others, and several copies (JNI, NAPI, PyO3) had no leak coverage at all.

This moves the lifecycle into two shared helpers on `glide_core::GlideOpenTelemetry`:

- `leak_span(span) -> u64` — moves the span into a fresh `Arc` and returns the raw pointer for transfer across the FFI/JNI boundary.
- `unsafe drop_span_ptr(u64)` — validates the pointer, treats `0` as a no-op (matching the bindings' "ignore null span" behavior), contains any panic so it cannot unwind across the FFI boundary, and reclaims the `Arc`.

All four bindings now route through the shared path. The create/drop pair is exercised by a leak-regression test asserting the `Arc` strong count returns to baseline over 1000 iterations, plus a null/invalid-pointer rejection test.

### Checklist

- [x] No public API or behavior change
- [x] CHANGELOG updated
- [x] Unit tests cover the shared create/drop path